### PR TITLE
Add gomon from oracle-cloud-agent

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,5 +14,6 @@
         foldMap (file: import file (inputs // { inherit lib; }));
     in
     mergeFlakeOutputs [
+      ./servers/oracle-cloud-agent
     ] // { inherit lib; };
 }

--- a/servers/oracle-cloud-agent/agent.yml.aarch64.patch
+++ b/servers/oracle-cloud-agent/agent.yml.aarch64.patch
@@ -1,0 +1,27 @@
+diff --git 1/agent.yml 2/agent.yml
+index c5199ad..5ae16fa 100644
+--- 1/agent.yml
++++ 2/agent.yml
+@@ -5,7 +5,7 @@ pluginHealthCheckInterval: "10m"
+ plugins:
+   gomon:
+     disabled: false
+-    exec: "/snap/oracle-cloud-agent/current/plugins/gomon/gomon"
++    exec: "@plugin@/bin/gomon"
+     elevated: false
+     args: []
+   bastions:
+@@ -15,11 +15,11 @@ plugins:
+       - "oc3"
+       - "oc6"
+       - "oc7"
+-    exec: "/var/snap/oracle-cloud-agent/common/bastions"
++    exec: "@plugin@/bin/bastions"
+     elevated: false
+     args: []
+   oci-vulnerabilityscan:
+-    exec: "/snap/oracle-cloud-agent/current/plugins/oci-vulnerabilityscan/oci-vulnerabilityscan"
++    exec: "@plugin@/bin/oci-vulnerabilityscan"
+     elevated: false
+     args: []
+     disabled: false

--- a/servers/oracle-cloud-agent/agent.yml.x86_64.patch
+++ b/servers/oracle-cloud-agent/agent.yml.x86_64.patch
@@ -1,0 +1,60 @@
+diff --git 1/agent.yml 2/agent.yml
+index b4d8012..3a07796 100644
+--- 1/agent.yml
++++ 2/agent.yml
+@@ -5,7 +5,7 @@ pluginHealthCheckInterval: "10m"
+ plugins:
+   gomon:
+     disabled: false
+-    exec: "/snap/oracle-cloud-agent/current/plugins/gomon/gomon"
++    exec: "@plugin@/bin/.gomon"
+     elevated: false
+     args: []
+   unifiedmonitoring:
+@@ -23,7 +23,7 @@ plugins:
+     disableByShape:
+       - "VM.Standard.E2.1.Micro"
+     disabled: false
+-    exec: "/snap/oracle-cloud-agent/current/plugins/unifiedmonitoring/unifiedmonitoring"
++    exec: "@plugin@/bin/.unifiedmonitoring"
+     args: []
+   bastions:
+     disabled: false
+@@ -32,11 +32,11 @@ plugins:
+       - "oc3"
+       - "oc6"
+       - "oc7"
+-    exec: "/var/snap/oracle-cloud-agent/common/bastions"
++    exec: "@plugin@/bin/.bastions"
+     elevated: false
+     args: []
+   oci-vulnerabilityscan:
+-    exec: "/snap/oracle-cloud-agent/current/plugins/oci-vulnerabilityscan/oci-vulnerabilityscan"
++    exec: "@plugin@/bin/.oci-vulnerabilityscan"
+     elevated: false
+     args: []
+     disabled: false
+@@ -46,7 +46,7 @@ plugins:
+       - "oc6"
+       - "oc7"
+   oci-managementagent:
+-    exec: "/snap/oracle-cloud-agent/current/plugins/oci-managementagent/oci-managementagent"
++    exec: "@plugin@/bin/.oci-managementagent"
+     elevated: false
+     args: []
+     disabled: false
+@@ -59,12 +59,12 @@ plugins:
+       - "oc11"
+       - "oc12"
+   oci-jms:
+-    exec: "/snap/oracle-cloud-agent/current/plugins/oci-jms/oci-jms"
++    exec: "@plugin@/bin/.oci-jms"
+     elevated: true
+     args:
+       - "-Djms.agentType=OCA"
+       - "-jar"
+-      - "oracle-jms-agent.jar"
++      - "@plugin@/lib/oracle-jms-agent.jar"
+     runas: "root"
+     disabled: false
+     disableByRealm:

--- a/servers/oracle-cloud-agent/default.nix
+++ b/servers/oracle-cloud-agent/default.nix
@@ -7,4 +7,5 @@ in
 lib.forSystems systems (system: {
   packages.${system}.${pname} =
     nixpkgs.legacyPackages.${system}.callPackage ./package.nix { };
+  nixosModules.gomon = import ./gomon.nix { pkgs = self.packages.${system}; };
 })

--- a/servers/oracle-cloud-agent/default.nix
+++ b/servers/oracle-cloud-agent/default.nix
@@ -1,0 +1,10 @@
+{ lib, nixpkgs, ... }:
+
+let
+  pname = "oracle-cloud-agent";
+  systems = [ "x86_64-linux" "aarch64-linux" ];
+in
+lib.forSystems systems (system: {
+  packages.${system}.${pname} =
+    nixpkgs.legacyPackages.${system}.callPackage ./package.nix { };
+})

--- a/servers/oracle-cloud-agent/default.nix
+++ b/servers/oracle-cloud-agent/default.nix
@@ -1,4 +1,4 @@
-{ lib, nixpkgs, ... }:
+{ self, lib, nixpkgs, ... }:
 
 let
   pname = "oracle-cloud-agent";
@@ -7,5 +7,9 @@ in
 lib.forSystems systems (system: {
   packages.${system}.${pname} =
     nixpkgs.legacyPackages.${system}.callPackage ./package.nix { };
+  apps.${system}.gomon = {
+    type = "app";
+    program = self.packages.${system}.${pname}.plugin + "/bin/gomon";
+  };
   nixosModules.gomon = import ./gomon.nix { pkgs = self.packages.${system}; };
 })

--- a/servers/oracle-cloud-agent/gomon.nix
+++ b/servers/oracle-cloud-agent/gomon.nix
@@ -1,0 +1,45 @@
+{ pkgs }:
+{ lib, config, ... }:
+
+let
+  cfg = config.services.gomon;
+  inherit (lib) types;
+
+in
+{
+  options.services.gomon = {
+    enable = lib.mkEnableOption "OCI monitoring with gomon";
+
+    package = lib.mkOption {
+      type = types.package;
+      default = pkgs.oracle-cloud-agent.plugin;
+      defaultText = lib.literalExpression "pkgs.oracle-cloud-agent.plugin";
+      description = "The package to use for gomon";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    systemd.services.gomon = {
+      description = "OCI monitoring with gomon";
+
+      after = [ "network-post.target" ];
+      wants = [ "network-post.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      stopIfChanged = false;
+
+      script = ''
+        ${cfg.package}/bin/gomon -cli -log-file /dev/stdout
+      '';
+
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = "3";
+        DynamicUser = true;
+        CapabilityBoundingSet = "";
+      };
+
+    };
+  };
+}

--- a/servers/oracle-cloud-agent/package.nix
+++ b/servers/oracle-cloud-agent/package.nix
@@ -1,0 +1,126 @@
+{ lib
+, stdenvNoCC
+, system
+
+, fetchurl
+, makeBinaryWrapper
+, squashfsTools
+}:
+
+let
+  pname = "oracle-cloud-agent";
+
+  input = lib.findFirst
+    (x: x.system == system)
+    (throw "No matching source for ${pname} on ${system}")
+    [
+      {
+        system = "x86_64-linux";
+        version = "1.24.0-9727";
+        url = "https://api.snapcraft.io/api/v1/snaps/download/ltx4XjES2e2ujitNIuO5GxPYDM6lp6ry_40.snap";
+        hash = "sha256-JYUX1QTsUEDb2uGkZVrXFO1wo8KHjtIiin4H3mckxdM=";
+        patches = [ ./agent.yml.x86_64.patch ];
+      }
+      {
+        system = "aarch64-linux";
+        url =
+          "https://api.snapcraft.io/api/v1/snaps/download/ltx4XjES2e2ujitNIuO5GxPYDM6lp6ry_41.snap";
+        version = "1.24.0-1";
+        hash = "sha256-ePpDb3ZpMWzxbBlVpCh2KFtsEWGimhD573s+UZLBmS8=";
+        patches = [ ./agent.yml.aarch64.patch ];
+      }
+    ];
+
+  src = fetchurl {
+    name = "${pname}-${input.version}-src";
+    inherit (input) url hash;
+    downloadToTemp = true;
+    recursiveHash = true;
+    postFetch = ''
+      ${squashfsTools}/bin/unsquashfs "$downloadedFile"
+      mkdir -p "$out"
+      cp -Rv squashfs-root/* "$out"
+    '';
+  };
+
+  meta = {
+    description = "Agent for oracle cloud instances";
+    homepage = "https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/manage-plugins.htm";
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    license = lib.licenses.upl;
+  };
+
+  PLUGINS = [
+    "gomon"
+    "oci-managementagent"
+    # "oci-jms"
+    "oci-vulnerabilityscan"
+    "unifiedmonitoring"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    substituteAllInPlace agent.yml
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/etc" "$plugin/bin" "$plugin/etc"
+
+    install -m750 -T agent "$out/bin/.agent"
+    install -m640 agent.yml "$out/etc/"
+
+    makeWrapper "$out/bin/.agent" "$out/bin/oracle-cloud-agent" \
+      --inherit-argv0 \
+      --add-flags "-agent-config $out/etc/agent.yml"
+
+    install -m750 -T plugins/bastions "$plugin/bin/bastions"
+    install -m640 -T plugins/bastions-config/config.yml "$plugin/etc/bastions.yml"
+
+    wrapProgram "$plugin/bin/bastions" \
+      --add-flags "-agent-config $plugin/etc/bastions.yml" \
+
+    for p in ''${PLUGINS[@]}; do
+      local PLUGIN_DIR="plugins/$p"
+      local PLUGIN_OUT="$plugin/bin/''${p}"
+      local CONFIG_OUT="$plugin/etc/''${p}.yml"
+
+      if [ ! -d $PLUGIN_DIR ]; then
+        continue
+      fi
+
+      local -a wrap_args=("$PLUGIN_OUT")
+
+      install -m750 -T "$PLUGIN_DIR/$p" "$PLUGIN_OUT"
+
+      if [ $p != oci-vulnerabilityscan ]; then
+        install -m640 -T "$PLUGIN_DIR/config/config.yml" "$CONFIG_OUT"
+        wrap_args+=(
+          --add-flags "-agent-config $CONFIG_OUT"
+        )
+      fi
+
+      wrapProgram "''${wrap_args[@]}"
+    done
+
+    runHook postInstall
+  '';
+
+in
+stdenvNoCC.mkDerivation {
+  inherit pname meta src;
+  inherit (input) version patches;
+
+  inherit buildPhase installPhase;
+  inherit PLUGINS;
+
+  outputs = [ "out" "plugin" ];
+
+  dontPatchELF = true;
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+}


### PR DESCRIPTION
This adds a `gomon` module, which runs the gomon monitor with systemd.
It is `gomon` that reports metrics to OCI.

The full `oracle-cloud-agent` application is available, but I only needed `gomon` for my purposes.

The binaries are from the snap.
The derivation extracts the various components into `out` and `plugin` outputs.
The `gomon` module handles this correctly.
