### PR TITLE
Add simple-markdown script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,8 @@
     mergeFlakeOutputs [
       ./utils/writers
 
+      ./scripts/pandoc
+
       ./servers/oracle-cloud-agent
     ] // { inherit lib; };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,9 @@
 
   outputs = { nixpkgs, ... }@inputs:
     let
-      lib = import ./flake-lib.nix { inherit nixpkgs; };
+      lib = import ./lib {
+        lib = import ./flake-lib.nix { inherit nixpkgs; };
+      };
 
       mergeFlakeOutputs =
         lib.foldMap (file: import file (inputs // { inherit lib; }));

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,8 @@
         lib.foldMap (file: import file (inputs // { inherit lib; }));
     in
     mergeFlakeOutputs [
+      ./utils/writers
+
       ./servers/oracle-cloud-agent
     ] // { inherit lib; };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+
+let
+  anyNix = lib.platforms.darwin ++ lib.platforms.linux;
+
+  dual = builtins.attrValues
+    { inherit (lib.licenses) bsd3 asl20; };
+
+  standalone =
+    { version
+    , script
+    , meta ? { }
+    , passthru ? { }
+    }:
+
+    script.overrideAttrs (old: {
+      inherit version;
+      meta = old.meta or { } // {
+        inherit version;
+        license = dual;
+        platforms = anyNix;
+      } // meta;
+      passthru = old.passthru or { } // passthru;
+    });
+
+in
+lib.recursiveUpdate lib {
+  platforms = { inherit anyNix; };
+  licenses = { inherit dual; };
+  inherit
+    standalone
+    ;
+}

--- a/scripts/pandoc/default.nix
+++ b/scripts/pandoc/default.nix
@@ -1,0 +1,16 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [ "simple-markdown" ];
+in
+lib.foldFor pnames (pname: lib.foldFor lib.platforms.all (system: {
+  packages.${system}.${pname} =
+    nixpkgs.legacyPackages.${system}.callPackage (./. + "/${pname}.nix") {
+      inherit (self.packages.${system}) writers;
+      inherit lib;
+    };
+  apps.${system}.${pname} = {
+    type = "app";
+    program = self.packages.${system}.${pname} + "/bin/${pname}";
+  };
+}))

--- a/scripts/pandoc/simple-markdown.nix
+++ b/scripts/pandoc/simple-markdown.nix
@@ -1,0 +1,62 @@
+{ lib
+, pandoc
+, writeText
+, writers
+}:
+let
+  pname = "simple-markdown";
+  version = "0.1.0";
+
+  lua = writeText "${pname}-filter" ''
+    function unwrap(el)
+      return el.content
+    end
+
+    return {
+      {
+        Span = unwrap,
+        Div = unwrap,
+        Link = function(l)
+          return pandoc.Link(l.content, l.target)
+        end,
+        Header = function(h)
+          return pandoc.Header(h.level, h.content)
+        end,
+        Code = function(c)
+          return pandoc.Code(c.text)
+        end,
+        CodeBlock = function(c)
+          return pandoc.CodeBlock(c.text)
+        end,
+      },
+    }
+  '';
+
+  script = writers.writeZshBin "${pname}" ''
+    convertPandoc() {
+      zparseopts -D -E -F -- \
+        -pandoc-extra-arg+:=pandoc_extra P+:=pandoc_extra \
+        -grid-tables=opt_grid_tables G=opt_grid_tables \
+        -markdown=opt_markdown m=opt_markdown
+
+      local FROM="$( (( #opt_markdown )) && echo "markdown" || echo "html" )"
+      local GRID_TABLES="$( (( #opt_grid_tables )) && echo "" || echo "-grid_tables" )"
+
+      local -a PANDOC_ARGS=(
+        -r''${FROM} -wmarkdown-smart-simple_tables-multiline_tables''${GRID_TABLES}
+        --wrap=none --lua-filter=${lua}
+      )
+
+      local PANDOC_EXTRA_SIGIL=(--pandoc-extra-arg -P)
+      PANDOC_ARGS+=("''${(@)pandoc_extra:|PANDOC_EXTRA_SIGIL}")
+
+      ${pandoc}/bin/pandoc "''${(@)PANDOC_ARGS}" </dev/stdin
+    }
+
+    convertPandoc "$@"
+  '';
+in
+lib.standalone {
+  inherit version script;
+  passthru = { inherit lua; };
+}

--- a/utils/writers/default.nix
+++ b/utils/writers/default.nix
@@ -1,0 +1,9 @@
+{ lib, nixpkgs, ... }:
+
+let
+  pnames = [ "writeZshBin" ];
+in
+lib.foldFor pnames (pname: lib.foldFor lib.platforms.all (system: {
+  packages.${system}.writers.${pname} =
+    nixpkgs.legacyPackages.${system}.callPackage (./. + "/${pname}.nix") { };
+}))

--- a/utils/writers/writeZshBin.nix
+++ b/utils/writers/writeZshBin.nix
@@ -1,0 +1,17 @@
+{ writers, zsh }:
+
+name: script:
+
+writers.makeScriptWriter { interpreter = "${zsh}/bin/zsh"; } "/bin/${name}" (
+  ''
+    set -euo pipefail
+
+    setopt EXTENDED_GLOB
+    setopt LOCAL_OPTIONS
+    setopt LOCAL_TRAPS
+    setopt ERR_EXIT
+
+    export LANG="''${LANG:-en_GB.UTF-8}"
+
+  '' + script
+)


### PR DESCRIPTION
This script is very useful for cleaning up html copied from browsers.

It requires tooling to build zsh scripts.

It also requires tooling to write wrappers; this could be cleaned up a little in a future version.
