### PR TITLE
Add pysplit script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
       ./utils/writers
 
       ./scripts/pandoc
+      ./scripts/text
 
       ./servers/oracle-cloud-agent
     ] // { inherit lib; };

--- a/scripts/text/default.nix
+++ b/scripts/text/default.nix
@@ -1,0 +1,15 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [ "pysplit" ];
+in
+lib.foldFor pnames (pname: lib.foldFor lib.platforms.all (system: {
+  packages.${system}.${pname} =
+    nixpkgs.legacyPackages.${system}.callPackage (./. + "/${pname}.nix") {
+      inherit (self.packages.${system}) writers;
+    };
+  apps.${system}.${pname} = {
+    type = "app";
+    program = self.packages.${system}.${pname} + "/bin/${pname}";
+  };
+}))

--- a/scripts/text/pysplit.nix
+++ b/scripts/text/pysplit.nix
@@ -1,0 +1,25 @@
+{ writers
+, python3Packages
+}:
+
+writers.writePythonBin "pysplit"
+{
+  libraries = builtins.attrValues
+    {
+      inherit (python3Packages) pysbd;
+    };
+} ''
+  import pysbd
+  import sys
+
+
+  def main():
+      text = sys.stdin.read()
+      seg = pysbd.Segmenter(language="en", clean=False)
+      for t in seg.segment(text):
+          print(t.rstrip())
+
+
+  if __name__ == "__main__":
+      main()
+''

--- a/utils/writers/default.nix
+++ b/utils/writers/default.nix
@@ -1,7 +1,7 @@
 { lib, nixpkgs, ... }:
 
 let
-  pnames = [ "writeZshBin" ];
+  pnames = [ "writePythonBin" "writeZshBin" ];
 in
 lib.foldFor pnames (pname: lib.foldFor lib.platforms.all (system: {
   packages.${system}.writers.${pname} =

--- a/utils/writers/writePythonBin.nix
+++ b/utils/writers/writePythonBin.nix
@@ -1,0 +1,40 @@
+{ lib
+, writers
+, python3
+, python3Packages
+}:
+
+let
+  # Vendored from pkgs/build-support/writers/default.nix
+  # I’ve added the `doCheck` flag
+  # makePythonWriter takes python and compatible pythonPackages and produces python script writer,
+  # which validates the script with flake8 at build time. If any libraries are specified,
+  # python.withPackages is used as interpreter, otherwise the "bare" python is used.
+  makePythonWriter =
+    python: pythonPackages: name:
+    { libraries ? [ ]
+    , flakeIgnore ? [ ]
+    , doCheck ? false
+    }:
+    let
+      inherit (lib) concatMapStringsSep escapeShellArg optionalString;
+      inherit (writers) makeScriptWriter writeDash;
+      ignoreAttribute = optionalString (flakeIgnore != [ ]) "--ignore ${concatMapStringsSep "," escapeShellArg flakeIgnore}";
+    in
+    makeScriptWriter
+      {
+        interpreter =
+          if libraries == [ ]
+          then "${python}/bin/python"
+          else "${python.withPackages (ps: libraries)}/bin/python"
+        ;
+        ${if doCheck then "check" else null} = writeDash "python2check.sh" ''
+          exec ${pythonPackages.flake8}/bin/flake8 --show-source ${ignoreAttribute} "$1"
+        '';
+      }
+      name;
+
+in
+name:
+
+makePythonWriter python3 python3Packages "/bin/${name}"


### PR DESCRIPTION
This splits text into sentences.

I'm sure there are better ways to do this but this one happens to get _most_ things right.
Notably, this handles basically all sentence-terminating punctuation, without overdoing it (titles, etc).

I could potentially work around its rough edges (only numbered lists comes to mind, but 🤷).

I had to vendor the python script writer from nixpkgs. It's not a substantial portion, so I haven't added the license block, but I _should_ upstream my change, I think, then remove the vendored code.