### PR TITLE
Expose overlays for packages

### DIFF
--- a/scripts/pandoc/default.nix
+++ b/scripts/pandoc/default.nix
@@ -3,14 +3,24 @@
 let
   pnames = [ "simple-markdown" ];
 in
-lib.foldFor pnames (pname: lib.foldFor lib.platforms.all (system: {
-  packages.${system}.${pname} =
-    nixpkgs.legacyPackages.${system}.callPackage (./. + "/${pname}.nix") {
-      inherit (self.packages.${system}) writers;
+{
+  overlays.pandoc = final: prev: lib.foldFor pnames (pname: {
+    ${pname} = prev.callPackage (./. + "/${pname}.nix") {
+      inherit (final) writers;
       inherit lib;
     };
-  apps.${system}.${pname} = {
-    type = "app";
-    program = self.packages.${system}.${pname} + "/bin/${pname}";
-  };
-}))
+  });
+} //
+lib.foldFor lib.platforms.all (system:
+  {
+    packages.${system} = self.overlays.pandoc
+      self.packages.${system}
+      nixpkgs.legacyPackages.${system};
+  } //
+  lib.foldFor pnames (pname: {
+    apps.${system}.${pname} = {
+      type = "app";
+      program = self.packages.${system}.${pname} + "/bin/${pname}";
+    };
+  })
+)

--- a/servers/oracle-cloud-agent/default.nix
+++ b/servers/oracle-cloud-agent/default.nix
@@ -4,9 +4,15 @@ let
   pname = "oracle-cloud-agent";
   systems = [ "x86_64-linux" "aarch64-linux" ];
 in
+{
+  overlays.${pname} = final: prev: {
+    ${pname} = prev.callPackage ./package.nix { };
+  };
+} //
 lib.foldFor systems (system: {
-  packages.${system}.${pname} =
-    nixpkgs.legacyPackages.${system}.callPackage ./package.nix { };
+  packages.${system} = self.overlays.${pname}
+    self.packages.${system}
+    nixpkgs.legacyPackages.${system};
   apps.${system}.gomon = {
     type = "app";
     program = self.packages.${system}.${pname}.plugin + "/bin/gomon";

--- a/utils/writers/default.nix
+++ b/utils/writers/default.nix
@@ -1,9 +1,15 @@
-{ lib, nixpkgs, ... }:
+{ self, lib, nixpkgs, ... }:
 
 let
   pnames = [ "writePythonBin" "writeZshBin" ];
 in
-lib.foldFor pnames (pname: lib.foldFor lib.platforms.all (system: {
-  packages.${system}.writers.${pname} =
-    nixpkgs.legacyPackages.${system}.callPackage (./. + "/${pname}.nix") { };
-}))
+{
+  overlays.writers = final: prev: lib.foldFor pnames (pname: {
+    writers.${pname} = prev.callPackage (./. + "/${pname}.nix") { };
+  });
+} //
+lib.foldFor lib.platforms.all (system: {
+  packages.${system} = self.overlays.writers
+    self.packages.${system}
+    nixpkgs.legacyPackages.${system};
+})


### PR DESCRIPTION
Be a good citizen; expose the overlays _and_ the flake packages.

The implementation avoids repetition by using the overlay (in each sub-flake) in the call to `packages`.
This is strictly not quite right, as I pass the nixpkgs as `prev` and the `self` packages as `final` (the latter should be the union of the two sets).
It seems ok, for now?

There's scope to pull out common patterns, and thereby reduce boilerplate.
For now, though, I think this is ok.
