### PR TITLE
Add markdown-to-sqlite

### DIFF
--- a/databases/sqlite/default.nix
+++ b/databases/sqlite/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ ];
+  pnames = [ "markdown-to-sqlite" ];
 in
 {
   overlays.sqlite = final: prev: {

--- a/databases/sqlite/default.nix
+++ b/databases/sqlite/default.nix
@@ -1,5 +1,8 @@
 { self, lib, nixpkgs, ... }:
 
+let
+  pnames = [ ];
+in
 {
   overlays.sqlite = final: prev: {
     sqlite-extended = prev.callPackage ./package.nix {
@@ -7,7 +10,11 @@
     };
     sqlitePlugins = prev.sqlitePlugins or { }
     // prev.callPackage ./plugins.nix { };
-  };
+  } // lib.foldFor pnames (pname: {
+    ${pname} = prev.callPackage (./. + "/${pname}.nix") {
+      inherit (final) python3Packages;
+    };
+  });
 } //
 lib.foldFor lib.platforms.all (system: {
   packages.${system} = self.overlays.sqlite

--- a/databases/sqlite/markdown-to-sqlite.nix
+++ b/databases/sqlite/markdown-to-sqlite.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "markdown-to-sqlite";
+  version = "1.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "simonw";
+    repo = pname;
+    rev = "7381ff6a9a301aacad6d58fb4e92bcae72e896ab";
+    hash = "sha256-TVZsDpqrdqmfpASNFL90ldEcjHmNK27flJJS9irw520=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  checkInputs = builtins.attrValues {
+    inherit (python3Packages)
+      pytest
+      ;
+  };
+
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      click
+      markdown
+      sqlite-utils
+      yamldown
+      ;
+  };
+
+  meta = {
+    description = "CLI tool for loading markdown files into a SQLite database";
+    license = lib.licenses.asl20;
+  };
+}

--- a/dependencies/python/default.nix
+++ b/dependencies/python/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ ];
+  pnames = [ "yamldown" ];
 
   newPackages = final: prev: lib.foldFor pnames (pname: {
     ${pname} = prev.callPackage (./. + "/${pname}.nix") {

--- a/dependencies/python/default.nix
+++ b/dependencies/python/default.nix
@@ -1,0 +1,29 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [ ];
+
+  newPackages = final: prev: lib.foldFor pnames (pname: {
+    ${pname} = prev.callPackage (./. + "/${pname}.nix") {
+      inherit (final) python3Packages;
+    };
+  });
+
+in
+{
+  overlays.python = final: prev: {
+    python3 = prev.python3.override {
+      packageOverrides = lib.composeManyExtensions [
+        (_: _: newPackages final prev)
+      ];
+    };
+
+    python3Packages = final.python3.pkgs;
+  };
+
+} //
+lib.foldFor lib.platforms.all (system: {
+  packages.${system} = self.overlays.python
+    self.packages.${system}
+    nixpkgs.legacyPackages.${system};
+})

--- a/dependencies/python/yamldown.nix
+++ b/dependencies/python/yamldown.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "yamldown";
+  version = "0.1.8";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "dougli1sqrd";
+    repo = pname;
+    rev = "07a3943ac38954b2e37f8ac57ccfe0ecaaf0f560";
+    hash = "sha256-5gVXv56x4VznNvXZdnXMOcxbcEhZvZoIf5WUTzQIO0M=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      pyyaml
+      ;
+  };
+
+  meta = {
+    description = "Python library for loading and dumping “yamldown” (markdown with embedded yaml) files.";
+    license = lib.licenses.bsd3;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,8 @@
 
     in
     buildFlakeFrom [
+      ./dependencies/python
+
       ./databases/sqlite
 
       ./utils/writers


### PR DESCRIPTION
This PR adds `markdown-to-sqlite` into the `sqlite` overlay.

It also adds a `dependencies/python` sub-flake, with a `python` overlay.
This means I can override python dependencies in this flake, as a whole, and (if I've implemented this correctly) propagate those changes downstream.
