### PR TITLE
Fix python overlays

### DIFF
--- a/dependencies/python/default.nix
+++ b/dependencies/python/default.nix
@@ -16,6 +16,12 @@ in
       pkgs = prev.python3.pkgs.overrideScope (lib.composeManyExtensions [
         (_: _: newPackages final prev)
       ]);
+
+      packageOverrides = lib.warn ''
+        `python3.packageOverrides` does not compose;
+        instead, manually replace the `pkgs` attr of `python3` with `python3.pkgs.overrideScope` applied to the overrides.
+      ''
+        prev.python3.packageOverrides;
     };
 
     python3Packages = final.python3.pkgs;

--- a/dependencies/python/default.nix
+++ b/dependencies/python/default.nix
@@ -12,10 +12,10 @@ let
 in
 {
   overlays.python = final: prev: {
-    python3 = prev.python3.override {
-      packageOverrides = lib.composeManyExtensions [
+    python3 = prev.python3 // {
+      pkgs = prev.python3.pkgs.overrideScope (lib.composeManyExtensions [
         (_: _: newPackages final prev)
-      ];
+      ]);
     };
 
     python3Packages = final.python3.pkgs;


### PR DESCRIPTION
Prefer manually replacing `python3.pkgs` with `python3.pkgs.overrideScope`, rather than using `python3.override` and setting `packageOverrides`.
The latter does not compose.
