### PR TITLE
Add sqlitebiter and dependencies

### DIFF
--- a/databases/sqlite/default.nix
+++ b/databases/sqlite/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ "markdown-to-sqlite" ];
+  pnames = [ "markdown-to-sqlite" "sqlitebiter" ];
 in
 {
   overlays.sqlite = final: prev: {

--- a/databases/sqlite/sqlitebiter.nix
+++ b/databases/sqlite/sqlitebiter.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "sqlitebiter";
+  version = "0.36.1";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "d0b5fa2d8a422b4834a37dd710724f6e4b19aedd";
+    hash = "sha256-PqwYLAN9KznlQiTYSTvZHuncSx/kUQzdC6IqOTE5XnU=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      SimpleSQLite
+      appconfigpy
+      click
+      envinfopy
+      loguru
+      msgfy
+      nbformat
+      path
+      pytablereader
+      retryrequests
+      tcolorpy
+      typepy
+      ;
+  };
+
+  meta = {
+    description = "A CLI tool to convert CSV / Excel / HTML / JSON / Jupyter Notebook / LDJSON / LTSV / Markdown / SQLite / SSV / TSV / Google-Sheets to a SQLite database file";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/DataProperty.nix
+++ b/dependencies/python/DataProperty.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "DataProperty";
+  version = "0.55.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "539d0a1d1b4b9ffcb6681c2d67d512f90eae5cf5";
+    hash = "sha256-ODSrKZ8M/ni9r2gkVIKWaKkdr+3AVi4INkEKJ+cmb44=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      mbstrdecoder
+      typepy
+      ;
+  };
+
+  meta = {
+    description = "A Python library for extract property from data";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/SimpleSQLite.nix
+++ b/dependencies/python/SimpleSQLite.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "SimpleSQLite";
+  version = "1.3.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "9ff8825e597dc9c787d486a62ce84d482a2320bc";
+    hash = "sha256-nHBlkElyfCoJ/8H8j5qc5f4mMwLUGOBJmKrQ0N0gQzE=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      DataProperty
+      mbstrdecoder
+      pathvalidate
+      sqliteschema
+      tabledata
+      typepy
+      ;
+  };
+
+  meta = {
+    description = "Python library to simplify SQLite database operations: table creation, data insertion and get data as other data formats";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/appconfigpy.nix
+++ b/dependencies/python/appconfigpy.nix
@@ -1,0 +1,29 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "appconfigpy";
+  version = "1.0.2";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "71aaa3110341ede8706a213cb1eb018a654ca8a6";
+    hash = "sha256-m2EyonJxzV0bqNmczcG14d1NAlrA9YvazFLZ+u/bu/A=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  meta = {
+    description = "A Python library to create/load an application configuration file";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/default.nix
+++ b/dependencies/python/default.nix
@@ -1,7 +1,22 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ "yamldown" ];
+  pnames = [
+    "DataProperty"
+    "SimpleSQLite"
+    "appconfigpy"
+    "envinfopy"
+    "excelrd"
+    "mbstrdecoder"
+    "msgfy"
+    "pytablereader"
+    "retryrequests"
+    "sqliteschema"
+    "tabledata"
+    "tcolorpy"
+    "typepy"
+    "yamldown"
+  ];
 
   newPackages = final: prev: lib.foldFor pnames (pname: {
     ${pname} = prev.callPackage (./. + "/${pname}.nix") {

--- a/dependencies/python/envinfopy.nix
+++ b/dependencies/python/envinfopy.nix
@@ -1,0 +1,29 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "envinfopy";
+  version = "0.0.7";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "0b68476d152e52d83ec349768c0d7b4502cbc3d3";
+    hash = "sha256-9b2j+gZ3P8QXbZZxw0Itep4zqgprfmTNqtFDPd5qC6A=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  meta = {
+    description = "A Python Library to get execution environment information";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/excelrd.nix
+++ b/dependencies/python/excelrd.nix
@@ -1,0 +1,29 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "excelrd";
+  version = "2.0.3";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "f48958517451301c24fb470bcb6b4f684145f91b";
+    hash = "sha256-wcEnzzLVffFyFt+4T1RogRUsWOl8wbGEn/Pi6qY3auQ=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  meta = {
+    description = "A modified version of xlrd to work for the latest Python versions";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/mbstrdecoder.nix
+++ b/dependencies/python/mbstrdecoder.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "mbstrdecoder";
+  version = "1.1.1";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "2e652d7d18ba9a16be5685f3625eac1f1f1c64b6";
+    hash = "sha256-U8F+mWKDulIRvvhswmdGnxKjM2qONQybViQ5TLZbLDY=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      chardet
+      ;
+  };
+
+  meta = {
+    description = "Python library for multi-byte character string decoder";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/msgfy.nix
+++ b/dependencies/python/msgfy.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "msgfy";
+  version = "0.2.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "63e1bcef4cbeb4f96e26eef1b80d017e8ff2d8d5";
+    hash = "sha256-UZWg8qat3ATomAImNp9e8pfrtYnuKeNEpr36ewFq0Ms=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      chardet
+      ;
+  };
+
+  meta = {
+    description = "A Python library for convert Exception instance to a human-readable error message";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/pytablereader.nix
+++ b/dependencies/python/pytablereader.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "pytablereader";
+  version = "0.31.3";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "b59859da6fdcc94035933dd253e6e380b04a233b";
+    hash = "sha256-iuAvdWw+0XVmBHs/90zEVw5FhHQjr1O3efDNK1LQzig=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      DataProperty
+      beautifulsoup4
+      pathvalidate
+      path
+      tabledata
+      typepy
+      jsonschema
+      # md optional dependencies
+      markdown
+      # excel optional dependencies
+      excelrd
+      # sqlite optional dependencies
+      SimpleSQLite
+      # url optional dependencies
+      retryrequests
+      ;
+  };
+
+  meta = {
+    description = "A Python library to load structured table data from files/strings/URL with various data format: CSV / Excel / Google-Sheets / HTML / JSON / LDJSON / LTSV / Markdown / SQLite / TSV";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/retryrequests.nix
+++ b/dependencies/python/retryrequests.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "retryrequests";
+  version = "0.2.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "b63a008da2e7cadc1fb2039b6912dc6bcb7345c0";
+    hash = "sha256-bla17VebkQlga6K+yGAd+XUxXz0Oh4Kem4i6tq29QxQ=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      requests
+      ;
+  };
+
+  meta = {
+    description = "A Python library that make HTTP requests with exponential back-off retry by using requests package";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/sqliteschema.nix
+++ b/dependencies/python/sqliteschema.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "sqliteschema";
+  version = "1.3.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "c599ca889658f3080fbf900110a3edb0541a6d35";
+    hash = "sha256-17MQkvMQo0b08+MEbVFsWdX6w2cYnr/NpKWAxeFnP+0=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      mbstrdecoder
+      tabledata
+      typepy
+      ;
+  };
+
+  meta = {
+    description = "Python library to dump table schema of a SQLite database file";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/tabledata.nix
+++ b/dependencies/python/tabledata.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "tabledata";
+  version = "1.3.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "8b6369c3e2114597e9cbbebc0f3c3eac77041561";
+    hash = "sha256-OMrK0ZrNJ6U7Hxi8LJfUOM2c4YbDJninXFAIiMKHw58=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      DataProperty
+      typepy
+      ;
+  };
+
+  meta = {
+    description = "Python library to represent tabular data";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/tcolorpy.nix
+++ b/dependencies/python/tcolorpy.nix
@@ -1,0 +1,29 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "tcolorpy";
+  version = "0.1.2";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "62280b8ab1b53e90835a480f4a28b712c9e18704";
+    hash = "sha256-duMbeKygEuGVcg4+gQRfClww3rs5AsmJR1VQBo7KWFY=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  meta = {
+    description = "A Python library to apply true color for terminal text";
+    license = lib.licenses.mit;
+  };
+}

--- a/dependencies/python/typepy.nix
+++ b/dependencies/python/typepy.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+let
+
+  pname = "typepy";
+  version = "1.2.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    owner = "thombashi";
+    repo = pname;
+    rev = "83fe150fb6135930c167322137c2c329363920ad";
+    hash = "sha256-GljfbJZT1PK//jt+J+QfiqP0/5p9B9y6VKDSB/++nt4=";
+  };
+
+in
+python3Packages.buildPythonPackage {
+  inherit pname version src;
+
+  doCheck = false;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (python3Packages)
+      mbstrdecoder
+      # datetime optional packages
+      packaging
+      python-dateutil
+      pytz
+      ;
+  };
+
+  meta = {
+    description = "A Python library for variable type checker/validator/converter at a run time";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
The package converts various tables to sqlite.

It required I add _many_ dependencies, which are all by the same author.

I have not added all the optional dependencies, given this has already taken longer than I'd have liked.

This is also very repetitive: it would be good to have a cleaner method (and one more amenable to updates) to add all the various dependencies.
