### PR TITLE
Propagate mtags from flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,47 @@
 {
   "nodes": {
+    "dbaynard": {
+      "inputs": {
+        "nixpkgs": [
+          "mtags",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1670524546,
+        "narHash": "sha256-ux4hUByieObd7FofACR1a8Fkj3gKyMAeO6T9Mk4AOB0=",
+        "owner": "dbaynard",
+        "repo": "flakes",
+        "rev": "8ed97379296daa9b46766fa9dcdd5c2450215f94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dbaynard",
+        "repo": "flakes",
+        "type": "github"
+      }
+    },
+    "mtags": {
+      "inputs": {
+        "dbaynard": "dbaynard",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1670633999,
+        "narHash": "sha256-fCH1Wr5BkAD4PMiGWEzs1lMdN6wojDbI70fYDl2f15g=",
+        "owner": "dbaynard",
+        "repo": "mtags",
+        "rev": "7117473fbc7bc9563d4ccd19d872532c298b103c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dbaynard",
+        "repo": "mtags",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1669411043,
@@ -16,6 +58,7 @@
     },
     "root": {
       "inputs": {
+        "mtags": "mtags",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,10 @@
       mergeFlakeOutputs =
         lib.foldMap (file: import file (inputs // { inherit lib; }));
 
+      flakeOverlays = [
+        inputs.mtags.overlays.default
+      ];
+
       buildFlakeFrom = files: lib.recursiveUpdate
         (mergeFlakeOutputs files)
         {
@@ -23,6 +27,7 @@
           overlays.default = lib.pipe self.overlays [
             (lib.filterAttrs (n: _: n != "default"))
             builtins.attrValues
+            (o: o ++ flakeOverlays)
             lib.composeManyExtensions
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "Miscellaneous custom packages";
 
+  inputs = {
+    mtags.url = "github:dbaynard/mtags";
+    mtags.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
   outputs = { self, nixpkgs, ... }@inputs:
     let
       lib = import ./lib {


### PR DESCRIPTION
This only propagates the derivation in the (default) overlay.

I could also add it to the set of packages, but that doesn't seem worth it.

I do need to pull out my flake-lib/lib utilities into a separate flake, to break the circular dependency loop.
