### PR TITLE
Add eml2html

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
 
       ./editors/language-server
 
+      ./utils/email
       ./utils/writers
 
       ./scripts/pandoc

--- a/utils/email/default.nix
+++ b/utils/email/default.nix
@@ -1,0 +1,15 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [ ];
+in
+{
+  overlays.email = final: prev: lib.foldFor pnames (pname: {
+    ${pname} = prev.callPackage (./. + "/${pname}.nix") { };
+  });
+} //
+lib.foldFor lib.platforms.all (system: {
+  packages.${system} = self.overlays.email
+    self.packages.${system}
+    nixpkgs.legacyPackages.${system};
+})

--- a/utils/email/default.nix
+++ b/utils/email/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ ];
+  pnames = [ "eml2html" ];
 in
 {
   overlays.email = final: prev: lib.foldFor pnames (pname: {

--- a/utils/email/eml2html.nix
+++ b/utils/email/eml2html.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+let
+  pname = "eml2html";
+  version = "1.0.4";
+  src = fetchFromGitHub {
+    name = "${pname}-${version}-src";
+    owner = "korylprince";
+    repo = pname;
+    rev = "c9258997dd52127ee54841453cea49bcb0f7d723";
+    hash = "sha256-8ezZWfrwMPDWBA4pKG8uYcmM4JvWOm/Y0KvXLwMvM60=";
+  };
+in
+buildGoModule {
+  inherit pname version src;
+
+  vendorHash = "sha256-KKfHX7PG72YmARt2LdHm2sYJDp5L/QyoNC5OEEiPBtE=";
+
+  meta = {
+    description = "Go library and command line tool to convert eml files to html";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
This is a particularly descriptive name.

It's quite good — but the output really needs to be served to see _all_ it does.
A plain converter it is not.

[korylprince/eml2html: Go library and command line tool to convert eml files to html](https://github.com/korylprince/eml2html)
