### PR TITLE
Add pgperms

### DIFF
--- a/databases/postgres/default.nix
+++ b/databases/postgres/default.nix
@@ -1,0 +1,15 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [ ];
+in
+{
+  overlays.postgres = final: prev: lib.foldFor pnames (pname: {
+    ${pname} = prev.callPackage (./. + "/${pname}.nix") { };
+  });
+} //
+lib.foldFor lib.platforms.all (system: {
+  packages.${system} = self.overlays.postgres
+    self.packages.${system}
+    nixpkgs.legacyPackages.${system};
+})

--- a/databases/postgres/default.nix
+++ b/databases/postgres/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ ];
+  pnames = [ "pgperms" ];
 in
 {
   overlays.postgres = final: prev: lib.foldFor pnames (pname: {

--- a/databases/postgres/pgperms.nix
+++ b/databases/postgres/pgperms.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+let
+  pname = "pgperms";
+  version = "0.1.0";
+  src = fetchFromGitHub {
+    name = "${pname}-${version}-src";
+    owner = "SnoozeThis-org";
+    repo = pname;
+    rev = "9e23a87bece464ed54e5206a24fbba0270cf5c2f";
+    hash = "sha256-obUXIL59BiKNP45h2nU9wwWTsFgIDlPDLFlmHlzqeFE=";
+  };
+in
+buildGoModule {
+  inherit pname version src;
+
+  vendorHash = "sha256-X1IB1vRK1yJfzEkl40ZH7kw2r61WfMYNaEhyDpifPSQ=";
+
+  doCheck = false;
+
+  meta = {
+    description = "Declarative PostgreSQL permissions as code";
+    license = lib.licenses.mit;
+  };
+}

--- a/databases/sqlite/default.nix
+++ b/databases/sqlite/default.nix
@@ -20,9 +20,4 @@ lib.foldFor lib.platforms.all (system: {
   packages.${system} = self.overlays.sqlite
     self.packages.${system}
     nixpkgs.legacyPackages.${system};
-
-  apps.${system}.sqlite = {
-    type = "app";
-    program = self.packages.${system}.sqlite + "/bin/sqlite3";
-  };
 })

--- a/databases/sqlite/package.nix
+++ b/databases/sqlite/package.nix
@@ -20,6 +20,8 @@ symlinkJoin {
     libPaths = lib.mapAttrs (_: d: d.libPath) plugins;
   };
 
+  meta.mainProgram = "sqlite3";
+
   postBuild = ''
     wrapProgram "$out/bin/sqlite3" \
       --prefix ${pathType}_LIBRARY_PATH : "$out/lib/sqlite/ext"

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
 
       ./deploy/org-formation
 
+      ./databases/postgres
       ./databases/sqlite
 
       ./editors/language-server


### PR DESCRIPTION
[SnoozeThis-org/pgperms at v0.1.0](https://github.com/SnoozeThis-org/pgperms/tree/v0.1.0).

> pgperms allows you to manage your PostgreSQL permissions in a configuration file. This follows the configuration as code paradigm and allows you to declaratively manage your PostgreSQL grants.
