### PR TITLE
Add tailscale-nginx-auth

### DIFF
--- a/servers/caddy/default.nix
+++ b/servers/caddy/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ "caddy-extended" ];
+  pnames = [ "caddy-extended" "tailscale-nginx-auth" ];
 in
 {
   overlays.caddy = final: prev: lib.foldFor pnames (pname: {

--- a/servers/caddy/tailscale-nginx-auth.nix
+++ b/servers/caddy/tailscale-nginx-auth.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, stdenvNoCC
 }:
 
 let
@@ -30,6 +31,17 @@ buildGoModule {
 
   CGO_ENABLED = 0;
   doCheck = false;
+
+  postInstall = lib.optionalString stdenvNoCC.isLinux ''
+    mkdir -p "$out/lib/systemd/system"
+
+    install -D -m0444 -t "$out/lib/systemd/system" \
+      "$src/cmd/nginx-auth/tailscale.nginx-auth.service"
+    install -D -m0444 -t "$out/lib/systemd/system" \
+      "$src/cmd/nginx-auth/tailscale.nginx-auth.socket"
+
+    sed -i -e "s#/usr/sbin#$out/bin#" "$out/lib/systemd/system/tailscale.nginx-auth.service"
+  '';
 
   meta = {
     description = "Use Tailscale Whois authentication with NGINX/Caddy as a reverse proxy";

--- a/servers/caddy/tailscale-nginx-auth.nix
+++ b/servers/caddy/tailscale-nginx-auth.nix
@@ -41,6 +41,10 @@ buildGoModule {
       "$src/cmd/nginx-auth/tailscale.nginx-auth.socket"
 
     sed -i -e "s#/usr/sbin#$out/bin#" "$out/lib/systemd/system/tailscale.nginx-auth.service"
+  '' + lib.optionalString stdenvNoCC.isDarwin ''
+    mkdir -p "$out/Library/LaunchAgents"
+    cp ${./tailscale-nginx-auth.plist} "$out/Library/LaunchAgents/org.nixos.tailscale.nginx-auth.plist"
+    substituteInPlace $out/Library/LaunchAgents/org.nixos.tailscale.nginx-auth.plist --subst-var out
   '';
 
   meta = {

--- a/servers/caddy/tailscale-nginx-auth.nix
+++ b/servers/caddy/tailscale-nginx-auth.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+let
+  pname = "tailscale-nginx-auth";
+  version = "0.1.0";
+  src = fetchFromGitHub {
+    name = "${pname}-${version}-src";
+    owner = "tailscale";
+    repo = "tailscale";
+    rev = "a353ae079b8b0c5205278585c8c0a42ba00185a6";
+    hash = "sha256-OntCgV5vQig5neCaKvKXJKK1FiwcmrdilE+qTdsVn1I=";
+  };
+in
+buildGoModule {
+  inherit pname version src;
+
+  subPackages = [ "cmd/nginx-auth" ];
+
+  vendorHash = "sha256-l2uIma2oEdSN0zVo9BOFJF2gC3S60vXwTLVadv8yQPo=";
+
+  patches = [
+    (builtins.path {
+      name = "${pname}.patch";
+      path = ./${pname}.patch;
+    })
+  ];
+
+  CGO_ENABLED = 0;
+  doCheck = false;
+
+  meta = {
+    description = "Use Tailscale Whois authentication with NGINX/Caddy as a reverse proxy";
+    license = lib.licenses.bsd3;
+  };
+}

--- a/servers/caddy/tailscale-nginx-auth.patch
+++ b/servers/caddy/tailscale-nginx-auth.patch
@@ -1,0 +1,13 @@
+diff --git i/cmd/nginx-auth/nginx-auth.go w/cmd/nginx-auth/nginx-auth.go
+index 09da74da..9770404a 100644
+--- i/cmd/nginx-auth/nginx-auth.go
++++ w/cmd/nginx-auth/nginx-auth.go
+@@ -1,7 +1,7 @@
+ // Copyright (c) Tailscale Inc & AUTHORS
+ // SPDX-License-Identifier: BSD-3-Clause
+ 
+-//go:build linux
++//go:build unix
+ 
+ // Command nginx-auth is a tool that allows users to use Tailscale Whois
+ // authentication with NGINX as a reverse proxy. This allows users that

--- a/servers/caddy/tailscale-nginx-auth.plist
+++ b/servers/caddy/tailscale-nginx-auth.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>org.nixos.tailscale.nginx-auth</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@out@/bin/tailscale.nginx-auth</string>
+  </array>
+  <key>KeepAlive</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>LaunchOnlyOnce</key>
+  <true/>
+  <key>Sockets</key>
+  <dict>
+    <key>ListenStream</key>
+    <dict>
+      <key>SockNodeName</key>
+      <string>/var/run/tailscale.nginx-auth.sock</string>
+    </dict>
+  </dict>
+  <key>ServiceIPC</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
I'm having to add additional functionality, for darwin, that I perhaps ought to push upstream?

I'll merge, then confirm everything works before doing that.
