### PR TITLE
Add postgres plugins starting with pg_uuidv7

### DIFF
--- a/databases/postgres/default.nix
+++ b/databases/postgres/default.nix
@@ -2,15 +2,18 @@
 
 let
   pnames = [ "pgperms" "storage-api" ];
+
+  pgs = [ "" "_15" "_14" ];
 in
 {
-  overlays.postgres = final: prev: {
-    postgresql = prev.postgresql.overrideAttrs (old: {
-      passthru = lib.recursiveUpdate old.passthru or { } {
-        pkgs = prev.callPackage ./plugins.nix { };
-      };
-    });
-  } // lib.foldFor pnames
+  overlays.postgres = final: prev: lib.foldFor pgs
+    (pg: {
+      "postgresql${pg}" = prev."postgresql${pg}".overrideAttrs (old: {
+        passthru = lib.recursiveUpdate old.passthru or { } {
+          pkgs = prev.callPackage ./plugins.nix { postgresql = prev."postgresql${pg}"; };
+        };
+      });
+    }) // lib.foldFor pnames
     (pname: {
       ${pname} = prev.callPackage (./. + "/${pname}.nix") { };
     });

--- a/databases/postgres/default.nix
+++ b/databases/postgres/default.nix
@@ -4,9 +4,16 @@ let
   pnames = [ "pgperms" "storage-api" ];
 in
 {
-  overlays.postgres = final: prev: lib.foldFor pnames (pname: {
-    ${pname} = prev.callPackage (./. + "/${pname}.nix") { };
-  });
+  overlays.postgres = final: prev: {
+    postgresql = prev.postgresql.overrideAttrs (old: {
+      passthru = lib.recursiveUpdate old.passthru or { } {
+        pkgs = prev.callPackage ./plugins.nix { };
+      };
+    });
+  } // lib.foldFor pnames
+    (pname: {
+      ${pname} = prev.callPackage (./. + "/${pname}.nix") { };
+    });
 } //
 lib.foldFor lib.platforms.all (system: {
   packages.${system} = self.overlays.postgres

--- a/databases/postgres/plugins.nix
+++ b/databases/postgres/plugins.nix
@@ -1,0 +1,6 @@
+{ lib
+, callPackage
+}:
+
+lib.mapAttrs (n: f: callPackage f { }) {
+}

--- a/databases/postgres/plugins.nix
+++ b/databases/postgres/plugins.nix
@@ -1,6 +1,45 @@
 { lib
 , callPackage
+, fetchFromGitHub
+, postgresql
 }:
 
-lib.mapAttrs (n: f: callPackage f { }) {
+let
+  pg_uuidv7 = { lib, stdenv, postgresql }:
+    let
+      pname = "pg_uuidv7";
+      version = "1.0.1";
+
+      src = fetchFromGitHub {
+        name = "${pname}-${version}-src";
+        repo = pname;
+        owner = "fboulnois";
+        rev = "486b1011ece3c7ad846aa9595042b5e12f4629d8";
+        hash = "sha256-/LIbyFq0QGbGAsDSLyaT6/f5LUaCphp087NqAwHDytU=";
+      };
+    in
+    stdenv.mkDerivation {
+      inherit pname version src;
+
+      buildInputs = [ postgresql ];
+
+      installPhase = ''
+        install -D -t "$out/lib" *.so
+        install -D -t "$out/share/postgresql/extension" *.sql
+        install -D -t "$out/share/postgresql/extension" *.control
+      '';
+
+      meta = {
+        description = "A tiny Postgres extension to create version 7 UUIDs";
+        homepage = "https://github.com/fboulnois/pg_uuidv7";
+        inherit (postgresql.meta) platforms;
+        license = lib.licenses.mpl20;
+      };
+    };
+
+in
+lib.mapAttrs (n: f: callPackage f { inherit postgresql; }) {
+  inherit
+    pg_uuidv7
+    ;
 }


### PR DESCRIPTION
It's good to know how to override postgres plugins such that downstream configurations just work.

Also for pg_uuidv7 value see [Unexpected downsides of UUID keys in PostgreSQL - CYBERTEC](https://www.cybertec-postgresql.com/en/unexpected-downsides-of-uuid-keys-in-postgresql/).
It's a locality issue.
