### PR TITLE
Add postgrest

### DIFF
--- a/databases/postgres/default.nix
+++ b/databases/postgres/default.nix
@@ -1,9 +1,13 @@
-{ self, lib, nixpkgs, ... }:
+{ self, lib, nixpkgs, postgrest, ... }:
 
 let
-  pnames = [ "pgperms" "storage-api" ];
+  pnames = [ "pgperms" "postgrest" "storage-api" ];
 
   pgs = [ "" "_15" "_14" ];
+
+  extras = {
+    postgrest = { inherit postgrest; };
+  };
 in
 {
   overlays.postgres = final: prev: lib.foldFor pgs
@@ -15,7 +19,9 @@ in
       });
     }) // lib.foldFor pnames
     (pname: {
-      ${pname} = prev.callPackage (./. + "/${pname}.nix") { };
+      ${pname} = prev.callPackage
+        (./. + "/${pname}.nix")
+        (extras."${pname}" or { });
     });
 } //
 lib.foldFor lib.platforms.all (system: {

--- a/databases/postgres/postgrest.nix
+++ b/databases/postgres/postgrest.nix
@@ -1,0 +1,10 @@
+{ lib
+, postgrest
+, system
+}:
+
+let
+  p = import postgrest.outPath { inherit system; };
+
+in
+p.postgrestStatic

--- a/flake.lock
+++ b/flake.lock
@@ -74,10 +74,28 @@
         "type": "indirect"
       }
     },
+    "postgrest": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1691675518,
+        "narHash": "sha256-fEmGPj9Y6K9Ni97oIABbje7zzkuraCbUkHLnxAE/Njw=",
+        "owner": "PostgREST",
+        "repo": "postgrest",
+        "rev": "c820efb64a2839c5cb7a6a82b9145c3d7065474c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "PostgREST",
+        "ref": "v11.2.0",
+        "repo": "postgrest",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "mtags": "mtags",
         "nixpkgs": "nixpkgs",
+        "postgrest": "postgrest",
         "rust": "rust"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,9 @@
 
     mtags.url = "github:dbaynard/mtags";
     mtags.inputs.nixpkgs.follows = "nixpkgs";
+
+    postgrest.url = "github:PostgREST/postgrest/v11.2.0";
+    postgrest.flake = false;
   };
 
   outputs = { self, nixpkgs, ... }@inputs:


### PR DESCRIPTION
Postgrest relies on non-hackage dependencies.
This is (systemically) annoying — that one of the proudest libraries should need to do this is not a good look for haskell.

However, it _does_ integrate with other infrastructure, which is great news.
For example, there is nix — see [postgrest/nix/README.md at v11.2.0 · PostgREST/postgrest](https://github.com/PostgREST/postgrest/blob/c820efb64a2839c5cb7a6a82b9145c3d7065474c/nix/README.md).
This uses a `default.nix`, though, rather than a flake, which is more than a little annoying… however, at least it has a `cachix` cache — [postgrest | Cachix](https://app.cachix.org/cache/postgrest).

I ought to transfer my cachix modules here, to enable CI to use cachix.
This particular implementation _really_ needs to use cachix, as it re-uses the hard-coded nixpkgs from upstream.
