### PR TITLE
Fix darwin postgres extensions

### DIFF
--- a/databases/postgres/plugins.nix
+++ b/databases/postgres/plugins.nix
@@ -26,6 +26,8 @@ let
 
       buildInputs = [ postgresql ];
 
+      buildFlags = lib.optionals usePlatformExtension [ ''DLSUFFIX=".so"'' ];
+
       installPhase = ''
         install -D -t "$out/lib" *.so
         install -D -t "$out/share/postgresql/extension" *.sql

--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691006197,
-        "narHash": "sha256-DbtxVWPt+ZP5W0Usg7jAyTomIM//c3Jtfa59Ht7AV8s=",
+        "lastModified": 1695644571,
+        "narHash": "sha256-asS9dCCdlt1lPq0DLwkVBbVoEKuEuz+Zi3DG7pR/RxA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "66aedfd010204949cb225cf749be08cb13ce1813",
+        "rev": "6500b4580c2a1f3d0f980d32d285739d8e156d92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This fix reverts the upstream change, to use `dylib`, and will likely have to be reverted when the problem is fixed upstream.
