### PR TITLE
Fix flake check and darwin eval

### DIFF
--- a/databases/sqlite/default.nix
+++ b/databases/sqlite/default.nix
@@ -17,7 +17,10 @@ in
   });
 } //
 lib.foldFor lib.platforms.all (system: {
-  packages.${system} = self.overlays.sqlite
-    self.packages.${system}
+  legacyPackages.${system} = self.overlays.sqlite
+    self.legacyPackages.${system}
     nixpkgs.legacyPackages.${system};
+  packages.${system} = lib.filterAttrs (_: a: lib.isDerivation a) (self.overlays.sqlite
+    self.legacyPackages.${system}
+    nixpkgs.legacyPackages.${system});
 })

--- a/dependencies/python/default.nix
+++ b/dependencies/python/default.nix
@@ -44,7 +44,7 @@ in
 
 } //
 lib.foldFor lib.platforms.all (system: {
-  packages.${system} = self.overlays.python
-    self.packages.${system}
+  legacyPackages.${system} = self.overlays.python
+    self.legacyPackages.${system}
     nixpkgs.legacyPackages.${system};
 })

--- a/dependencies/python/default.nix
+++ b/dependencies/python/default.nix
@@ -26,21 +26,25 @@ let
 
 in
 {
-  overlays.python = final: prev: {
-    python3 = prev.python3 // {
-      pkgs = prev.python3.pkgs.overrideScope (lib.composeManyExtensions [
+  overlays.python = final: prev:
+    let
+      pythonPkgsScope = prev.python3.pkgs.overrideScope (prev.lib.composeManyExtensions [
         (_: _: newPackages final prev)
       ]);
+    in
+    {
+      python3 = prev.python3 // {
+        pkgs = pythonPkgsScope;
 
-      packageOverrides = lib.warn ''
-        `python3.packageOverrides` does not compose;
-        instead, manually replace the `pkgs` attr of `python3` with `python3.pkgs.overrideScope` applied to the overrides.
-      ''
-        prev.python3.packageOverrides;
+        packageOverrides = lib.warn ''
+          `python3.packageOverrides` does not compose;
+          instead, manually replace the `pkgs` attr of `python3` with `python3.pkgs.overrideScope` applied to the overrides.
+        ''
+          prev.python3.packageOverrides;
+      };
+
+      python3Packages = pythonPkgsScope;
     };
-
-    python3Packages = final.python3.pkgs;
-  };
 
 } //
 lib.foldFor lib.platforms.all (system: {

--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "dbaynard": {
-      "inputs": {
-        "nixpkgs": [
-          "mtags",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1670524546,
-        "narHash": "sha256-ux4hUByieObd7FofACR1a8Fkj3gKyMAeO6T9Mk4AOB0=",
-        "owner": "dbaynard",
-        "repo": "flakes",
-        "rev": "8ed97379296daa9b46766fa9dcdd5c2450215f94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dbaynard",
-        "repo": "flakes",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -60,27 +39,6 @@
         "owner": "fore-stun",
         "ref": "fix-recursive-symlinker",
         "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
-    "mtags": {
-      "inputs": {
-        "dbaynard": "dbaynard",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1670636405,
-        "narHash": "sha256-I1oBD2TJH6cbBS5AYCvC2by/+p7TKBAG4wbdF5kQJYs=",
-        "owner": "dbaynard",
-        "repo": "mtags",
-        "rev": "b06c9e61f78d6b0cf678dcb23f4bfa6ed6b017ea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dbaynard",
-        "repo": "mtags",
         "type": "github"
       }
     },
@@ -137,7 +95,6 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "gomod2nix": "gomod2nix",
-        "mtags": "mtags",
         "nixpkgs": "nixpkgs",
         "postgrest": "postgrest",
         "rust": "rust",

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,6 @@
     rust.inputs.nixpkgs.follows = "nixpkgs";
     rust.inputs.flake-utils.follows = "flake-utils";
 
-    mtags.url = "github:dbaynard/mtags";
-    mtags.inputs.nixpkgs.follows = "nixpkgs";
-
     postgrest.url = "github:fore-stun/postgrest/flake";
 
     gomod2nix.url = "github:fore-stun/gomod2nix/fix-recursive-symlinker";
@@ -33,7 +30,6 @@
         lib.foldMap (file: import file (inputs // { inherit lib; }));
 
       flakeOverlays = [
-        inputs.mtags.overlays.default
         inputs.spanx.overlays.default
       ];
 

--- a/scripts/nix/default.nix
+++ b/scripts/nix/default.nix
@@ -16,7 +16,7 @@ in
 lib.foldFor lib.platforms.all (system:
   {
     packages.${system} = self.overlays.nix-script
-      self.packages.${system}
+      self.legacyPackages.${system}
       nixpkgs.legacyPackages.${system};
   } //
   lib.foldFor pnames (pname: {

--- a/scripts/pandoc/default.nix
+++ b/scripts/pandoc/default.nix
@@ -17,7 +17,7 @@ in
 lib.foldFor lib.platforms.all (system:
   {
     packages.${system} = self.overlays.pandoc
-      self.packages.${system}
+      self.legacyPackages.${system}
       nixpkgs.legacyPackages.${system};
   } //
   lib.foldFor pnames (pname: {

--- a/scripts/sync/default.nix
+++ b/scripts/sync/default.nix
@@ -14,7 +14,7 @@ in
 lib.foldFor lib.platforms.all (system:
   {
     packages.${system} = self.overlays.sync
-      self.packages.${system}
+      self.legacyPackages.${system}
       nixpkgs.legacyPackages.${system};
   } //
   lib.foldFor pnames (pname: {

--- a/scripts/text/default.nix
+++ b/scripts/text/default.nix
@@ -13,7 +13,7 @@ in
 lib.foldFor lib.platforms.all (system:
   {
     packages.${system} = self.overlays.text
-      self.packages.${system}
+      self.legacyPackages.${system}
       nixpkgs.legacyPackages.${system};
   } //
   lib.foldFor pnames (pname: {

--- a/utils/exif/default.nix
+++ b/utils/exif/default.nix
@@ -13,6 +13,6 @@ in
 } //
 lib.foldFor lib.platforms.all (system: {
   packages.${system} = self.overlays.exif
-    self.packages.${system}
+    self.legacyPackages.${system}
     nixpkgs.legacyPackages.${system};
 })

--- a/utils/writers/default.nix
+++ b/utils/writers/default.nix
@@ -11,7 +11,7 @@ in
   };
 } //
 lib.foldFor lib.platforms.all (system: {
-  packages.${system} = self.overlays.writers
-    self.packages.${system}
+  legacyPackages.${system} = self.overlays.writers
+    self.legacyPackages.${system}
     nixpkgs.legacyPackages.${system};
 })


### PR DESCRIPTION
This fixes a major (blocking) issue when applying this overlay for recent-ish nixpkgs on MacOS.
Overriding `python3Packages` to be `final.python3.pkgs` resulted in an attempt to rebuild _everything_ just to evaluate the system expression.
This was completely unviable: the fix (as included here) is to override the pkgs scope separately, and then assign that as the `python3Packages`.

Then there were many non-derivations at the top level in `packages`, which is not supported, and results in errors from `nix flake check`.
These attrsets (and some other derivations) had to move to `legacyPackages`.
I may make a more principled version of this, at some point… not now, though.

Beyond that, I was including `mtags` as a dependency, which in turn depends on this flake (an earlier version).
I'm not using `mtags` and it is available as a separate flake _anyway_, so there was no need to include it here, too.
