### PR TITLE
Implement sentence splitting with simple-markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 result*
 Session.vim
+
+scratch/

--- a/dependencies/lua/LuaNLP.nix
+++ b/dependencies/lua/LuaNLP.nix
@@ -1,0 +1,66 @@
+{ lib
+, fetchFromGitHub
+, lua
+}:
+let
+
+  pname = "LuaNLP";
+  version = "unstable-2022-09-08";
+  name = "${pname}-${version}";
+
+  owner = "pncnmnp";
+  repo = pname;
+
+  src = fetchFromGitHub {
+    name = "${name}-src";
+    inherit owner repo;
+    rev = "2f8dc3a178f66a0ef6925a47fa0a99bcf30e2dd9";
+    hash = "sha256-km6KQZS9KDSzuQQtuEA9CB0DU70k8A3w/9VNnY6bS1Q=";
+  };
+
+in
+lua.pkgs.buildLuaPackage {
+  inherit pname version src;
+
+  propagatedBuildInputs = builtins.attrValues {
+    inherit (lua.pkgs)
+      lrexlib-pcre
+      ;
+  };
+
+  dontBuild = true;
+
+  # LUA_LIBDIR = "$out/lib/lua/${lua.luaversion}";
+  # LUA_SHAREDIR = "$out/share/lua/${lua.luaversion}";
+
+  installPhase = ''
+    runHook preInstall
+
+    LUA_SHAREDIR="$out/share/lua/${lua.luaversion}";
+    mkdir -p "''${LUA_SHAREDIR?}"
+
+    find . -type d -exec install -vdm755 "{}" "''${LUA_SHAREDIR?}/{}" \;
+
+    find . -type f -name '*.lua' -exec install -vm755 "{}" "''${LUA_SHAREDIR?}/{}" \;
+    find lemmatizer/wordnet/ -type f -name '*.*' -exec install -vm644 "{}" "''${LUA_SHAREDIR?}/{}" \;
+    find sent/vader_lexicons/ -type f ! -name 'README*' -exec install -vm644 "{}" "''${LUA_SHAREDIR?}/{}" \;
+    find stopword/stoplists/ -type f ! -name 'README*' -exec install -vm644 "{}" "''${LUA_SHAREDIR?}/{}" \;
+    find tokenizer -type f -name treebank.json -exec install -vm644 "{}" "''${LUA_SHAREDIR?}/{}" \;
+
+    mkdir -p "$out/share/doc"
+
+    find . -type d -exec install -vdm755 "{}" "$out/share/doc/{}" \;
+
+    find . -type f -name README.md -exec install -vm644 "{}" "$out/share/doc/{}" \;
+    find . -type f -name README -exec install -vm644 "{}" "$out/share/doc/{}" \;
+    find . -type f -name 'HOWTO*' -exec install -vm644 "{}" "$out/share/doc/{}" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Natural Language Processing Library for Lua";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/${owner}/${repo}";
+  };
+}

--- a/dependencies/lua/default.nix
+++ b/dependencies/lua/default.nix
@@ -1,0 +1,41 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [
+  ];
+
+  newPackages = lua: final: prev: lib.foldFor pnames (pname: {
+    ${pname} = prev.callPackage (./. + "/${pname}.nix") {
+      lua = final.${lua};
+    };
+  });
+
+in
+{
+  overlays.lua = final: prev: lib.foldFor [ "luajit" "lua5" "lua5_4" ] (lua:
+    let
+      luaPkgsScope = prev.${lua}.pkgs.overrideScope (prev.lib.composeManyExtensions [
+        (_: _: newPackages lua final prev)
+      ]);
+    in
+    {
+      ${lua} = prev.${lua} // {
+        pkgs = luaPkgsScope;
+
+        packageOverrides = lib.warn ''
+          `${lua}.packageOverrides` does not compose;
+          instead, manually replace the `pkgs` attr of `${lua}` with `${lua}.pkgs.overrideScope` applied to the overrides.
+        ''
+          prev.${lua}.packageOverrides;
+      };
+
+      "${builtins.replaceStrings ["_"] [""] lua}Packages" = luaPkgsScope;
+    });
+
+} //
+lib.foldFor lib.platforms.all (system: {
+  legacyPackages.${system} = self.overlays.lua
+    self.legacyPackages.${system}
+    nixpkgs.legacyPackages.${system};
+})
+

--- a/dependencies/lua/default.nix
+++ b/dependencies/lua/default.nix
@@ -2,6 +2,7 @@
 
 let
   pnames = [
+    "LuaNLP"
   ];
 
   newPackages = lua: final: prev: lib.foldFor pnames (pname: {

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
     in
     buildFlakeFrom [
       ./dependencies/python
+      ./dependencies/lua
 
       ./deploy/aztfexport
       ./deploy/org-formation

--- a/scripts/pandoc/default.nix
+++ b/scripts/pandoc/default.nix
@@ -7,12 +7,17 @@ let
   ];
 in
 {
-  overlays.pandoc = final: prev: lib.foldFor pnames (pname: {
-    ${pname} = prev.callPackage (./. + "/${pname}.nix") {
-      inherit (final) writers;
-      inherit lib;
-    };
-  });
+  overlays.pandoc = final: prev:
+    let
+      extras = {
+      };
+    in
+    lib.foldFor pnames (pname: {
+      ${pname} = prev.callPackage (./. + "/${pname}.nix") ({
+        inherit (final) writers;
+        inherit lib;
+      } // extras."${pname}" or { });
+    });
 } //
 lib.foldFor lib.platforms.all (system:
   {

--- a/scripts/pandoc/default.nix
+++ b/scripts/pandoc/default.nix
@@ -10,6 +10,9 @@ in
   overlays.pandoc = final: prev:
     let
       extras = {
+        simple-markdown = {
+          lua = final.lua5_4;
+        };
       };
     in
     lib.foldFor pnames (pname: {

--- a/scripts/pandoc/simple-markdown.nix
+++ b/scripts/pandoc/simple-markdown.nix
@@ -10,6 +10,9 @@ let
   version = "0.1.0";
 
   libraries = builtins.attrValues {
+    inherit (lua.pkgs)
+      LuaNLP
+      ;
   };
 
   initLua =
@@ -47,21 +50,94 @@ let
     }
   '';
 
+  split = writers.writeLuaBin lua "${pname}-split-filter.lua"
+    {
+      inherit libraries; doCheck = "lua54+pandoc";
+    } ''
+    local tokenization = require("tokenizer.tokenization")
+
+    local function patcher(toreplace)
+      local space = 0
+      local replacement = 1
+
+      local function patch(el)
+        space = space + 1
+        if space == toreplace[replacement] then
+          replacement = replacement + 1
+          return pandoc.Str("\n")
+        end
+        return el
+      end
+
+      return {
+        -- traverse = 'topdown',
+        Space = patch,
+        SoftBreak = patch,
+      }
+    end
+
+    local function trackspace(spaces)
+      local function track(el)
+        spaces[1] = spaces[1] + 1
+        return el
+      end
+
+      return {
+        traverse = "topdown",
+        Space = track,
+        SoftBreak = track,
+      }
+    end
+
+    local function tokenize(el)
+      local tokens = tokenization.sentence_tokenize(pandoc.utils.stringify(el.content))
+      local toreplace = pandoc.List()
+
+      local i = 0
+      for tok in tokens do
+        if i > 0 then
+          i = i + 1
+          toreplace:insert(i)
+        end
+        local spaces = { 0 }
+        pandoc.Inlines(tok):walk(trackspace(spaces))
+        i = i + spaces[1]
+      end
+
+      el.content = el.content:walk(patcher(toreplace))
+      return el
+    end
+
+    return {
+      {
+        Para = tokenize,
+        Plain = tokenize,
+      },
+    }
+  '';
+
   script = writers.writeZshBin "${pname}" ''
     convertPandoc() {
       zparseopts -D -E -F -- \
         -pandoc-extra-arg+:=pandoc_extra P+:=pandoc_extra \
         -grid-tables=opt_grid_tables G=opt_grid_tables \
+        -no-split=opt_no_split S=opt_no_split \
         -markdown=opt_markdown m=opt_markdown
 
       local FROM="$( (( #opt_markdown )) && echo "markdown" || echo "html" )"
       local GRID_TABLES="$( (( #opt_grid_tables )) && echo "" || echo "-grid_tables" )"
+
+      local no_split="$( (( #opt_no_split )) && echo "" || echo "-no_split" )"
 
       local -a PANDOC_ARGS=(
         -r''${FROM} -wmarkdown-smart-simple_tables-multiline_tables''${GRID_TABLES}
         --data-dir=${initLua}
         --wrap=none --lua-filter=${strip}
       )
+
+      if ! (( #opt_no_split )); then
+        PANDOC_ARGS+=(--lua-filter=${lib.getExe split})
+      fi
 
       local PANDOC_EXTRA_SIGIL=(--pandoc-extra-arg -P)
       PANDOC_ARGS+=("''${(@)pandoc_extra:|PANDOC_EXTRA_SIGIL}")
@@ -74,5 +150,5 @@ let
 in
 lib.standalone {
   inherit version script;
-  passthru = { inherit initLua strip; };
+  passthru = { inherit initLua strip split; };
 }

--- a/scripts/text/pysplit.nix
+++ b/scripts/text/pysplit.nix
@@ -19,6 +19,9 @@ writers.writePythonBin "pysplit"
       text = sys.stdin.read().splitlines()
       seg = pysbd.Segmenter(language="en", clean=False)
       for chunk in ("\n".join(l) for _, l in groupby(text, lambda x: x != "")):
+          if chunk.startswith("#"):
+              print(chunk)
+              continue
           for t in seg.segment(chunk) or [""]:
               print(t.rstrip())
 

--- a/utils/writers/default.nix
+++ b/utils/writers/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ "writePythonBin" "writeZshBin" ];
+  pnames = [ "writeLuaBin" "writePythonBin" "writeZshBin" ];
 in
 {
   overlays.writers = final: prev: {

--- a/utils/writers/writeLuaBin.nix
+++ b/utils/writers/writeLuaBin.nix
@@ -1,0 +1,33 @@
+{ lib
+, writers
+}:
+
+let
+  # Vendored from pkgs/build-support/writers/default.nix
+  # I’ve added the `doCheck` flag
+
+  # makeLuaWriter takes lua and compatible luaPackages and produces lua script writer,
+  # which validates the script with luacheck at build time. If any libraries are specified,
+  # lua.withPackages is used as interpreter, otherwise the "bare" lua is used.
+  makeLuaWriter =
+    lua: name:
+    { libraries ? [ ]
+    , doCheck ? false
+    }:
+    writers.makeScriptWriter
+      {
+        interpreter =
+          if libraries == [ ]
+          then lua.interpreter
+          else (lua.withPackages (_: libraries)).interpreter
+        ;
+        ${if doCheck then "check" else null} = writers.writeDash "luacheck.sh" ''
+          exec ${lib.getExe lua.pkgs.luacheck} "$1"
+        '';
+      }
+      name;
+
+in
+lua: name:
+
+makeLuaWriter lua "/bin/${name}"


### PR DESCRIPTION
This adds a lua filter that identifies sentence endings, and then patches newlines into the AST.

As part of this, it does the following.

1.  Adds a lua dependency.
2.  Patches `writeLuaBin` to customize the checking.
3.  Create a pandoc data-dir with an `init.lua`.
4.  Adds the new filter.
