### PR TITLE
Extend caddy within this flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708296515,
-        "narHash": "sha256-FyF489fYNAUy7b6dkYV6rGPyzp+4tThhr80KNAaF/yY=",
+        "lastModified": 1709479366,
+        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b98a4e1746acceb92c509bc496ef3d0e5ad8d4aa",
+        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -61,8 +61,7 @@
         "flake-utils": "flake-utils",
         "gomod2nix": "gomod2nix",
         "nixpkgs": "nixpkgs",
-        "rust": "rust",
-        "spanx": "spanx"
+        "rust": "rust"
       }
     },
     "rust": {
@@ -85,32 +84,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "spanx": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "gomod2nix": [
-          "gomod2nix"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1700528264,
-        "narHash": "sha256-MLoOiItnbEco4GwxBXcwjn9u5FYh/6HQVX6fCh69c4c=",
-        "owner": "fore-stun",
-        "repo": "spanx",
-        "rev": "9e9109e6b964cd36fb9cb1be8328b0f32b3d60c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "fore-stun",
-        "repo": "spanx",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,7 @@
       mergeFlakeOutputs =
         lib.foldMap (file: import file (inputs // { inherit lib; }));
 
-      flakeOverlays = [
-        inputs.spanx.overlays.default
-      ];
+      flakeOverlays = [ ];
 
       buildFlakeFrom = files: lib.recursiveUpdate
         (mergeFlakeOutputs files)

--- a/flake.nix
+++ b/flake.nix
@@ -11,11 +11,6 @@
     gomod2nix.url = "github:fore-stun/gomod2nix/fix-recursive-symlinker";
     gomod2nix.inputs.nixpkgs.follows = "nixpkgs";
     gomod2nix.inputs.flake-utils.follows = "flake-utils";
-
-    spanx.url = "github:fore-stun/spanx";
-    spanx.inputs.nixpkgs.follows = "nixpkgs";
-    spanx.inputs.gomod2nix.follows = "gomod2nix";
-    spanx.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = { self, nixpkgs, ... }@inputs:

--- a/servers/caddy/caddy-extended.nix
+++ b/servers/caddy/caddy-extended.nix
@@ -1,0 +1,12 @@
+{ caddyWith
+, fetchXCaddy
+}:
+
+caddyWith {
+  plugins = [
+    "github.com/fore-stun/spanx"
+    "github.com/greenpau/caddy-security"
+    "github.com/lindenlab/caddy-s3-proxy"
+  ];
+  vendorHash = "sha256-y7iq9v2KDc5N5W4JRJtnVeG3CpjzlGAUYo3Qk0IkjFk=";
+}

--- a/servers/caddy/caddyWith.nix
+++ b/servers/caddy/caddyWith.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildGoModule
+, caddy
+, fetchXCaddy
+}:
+
+{ plugins
+, vendorHash
+}:
+
+lib.fix (caddyWith: (
+  caddy.override {
+    buildGoModule = args: buildGoModule (args // {
+      src = fetchXCaddy {
+        inherit plugins vendorHash;
+      };
+
+      subPackages = [ "." ];
+      ldflags = [ "-s" "-w" ]; ## don't include version info twice
+      vendorHash = null;
+    });
+  }).overrideAttrs (old: {
+  passthru = old.passthru or { } // {
+    inherit caddyWith fetchXCaddy;
+  };
+}))

--- a/servers/caddy/default.nix
+++ b/servers/caddy/default.nix
@@ -14,9 +14,14 @@ let
 
 in
 {
-  overlays.caddy = final: prev: lib.foldFor pnames (pname: {
-    ${pname} = prev.callPackage (./. + "/${pname}.nix") { };
-  });
+  overlays.caddy = final: prev:
+    let
+      extras = { };
+    in
+    lib.foldFor pnames (pname: {
+      ${pname} =
+        prev.callPackage (./. + "/${pname}.nix") (extras.${pname} or { });
+    });
 } //
 lib.foldFor lib.platforms.all (system:
   let pkgs = nixpkgs.legacyPackages.${system};

--- a/servers/caddy/default.nix
+++ b/servers/caddy/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ "tailscale-nginx-auth" ];
+  pnames = [ "caddy-extended" "tailscale-nginx-auth" ];
 
   forAarch64Linux = pkgs: drv: (drv.override {
     inherit (pkgs.pkgsCross.aarch64-multiplatform-musl) hostPlatform;
@@ -20,7 +20,7 @@ in
       caddyWith = prev.callPackage ./caddyWith.nix {
         inherit fetchXCaddy;
       };
-      extras = { };
+      extras = { caddy-extended = { inherit fetchXCaddy caddyWith; }; };
     in
     lib.foldFor pnames (pname: {
       ${pname} =

--- a/servers/caddy/default.nix
+++ b/servers/caddy/default.nix
@@ -22,12 +22,15 @@ lib.foldFor lib.platforms.all (system:
   let pkgs = nixpkgs.legacyPackages.${system};
   in
   {
-    packages.${system} = self.overlays.caddy
-      self.packages.${system}
+    packages.${system} =
+      lib.filterAttrs (_: lib.isDerivation) self.legacyPackages.${system} // {
+        tailscale-nginx-auth-aarch64-linux =
+          forAarch64Linux pkgs self.packages.${system}.tailscale-nginx-auth;
+      };
+    legacyPackages.${system} = self.overlays.caddy
+      self.legacyPackages.${system}
       pkgs // {
       caddy-extended = let spanxPkgs = spanx.packages.${system}; in
         spanxPkgs.${system} or spanxPkgs.default;
-      tailscale-nginx-auth-aarch64-linux =
-        forAarch64Linux pkgs self.packages.${system}.tailscale-nginx-auth;
     };
   })

--- a/servers/caddy/default.nix
+++ b/servers/caddy/default.nix
@@ -1,4 +1,4 @@
-{ self, lib, nixpkgs, spanx, ... }:
+{ self, lib, nixpkgs, ... }:
 
 let
   pnames = [ "tailscale-nginx-auth" ];
@@ -17,6 +17,9 @@ in
   overlays.caddy = final: prev:
     let
       fetchXCaddy = prev.callPackage ./fetchXCaddy.nix { };
+      caddyWith = prev.callPackage ./caddyWith.nix {
+        inherit fetchXCaddy;
+      };
       extras = { };
     in
     lib.foldFor pnames (pname: {
@@ -25,7 +28,8 @@ in
     });
 } //
 lib.foldFor lib.platforms.all (system:
-  let pkgs = nixpkgs.legacyPackages.${system};
+  let
+    pkgs = nixpkgs.legacyPackages.${system};
   in
   {
     packages.${system} =
@@ -35,8 +39,5 @@ lib.foldFor lib.platforms.all (system:
       };
     legacyPackages.${system} = self.overlays.caddy
       self.legacyPackages.${system}
-      pkgs // {
-      caddy-extended = let spanxPkgs = spanx.packages.${system}; in
-        spanxPkgs.${system} or spanxPkgs.default;
-    };
+      pkgs;
   })

--- a/servers/caddy/default.nix
+++ b/servers/caddy/default.nix
@@ -16,6 +16,7 @@ in
 {
   overlays.caddy = final: prev:
     let
+      fetchXCaddy = prev.callPackage ./fetchXCaddy.nix { };
       extras = { };
     in
     lib.foldFor pnames (pname: {

--- a/servers/caddy/fetchXCaddy.nix
+++ b/servers/caddy/fetchXCaddy.nix
@@ -1,0 +1,44 @@
+{ lib
+, cacert
+, caddy
+, go
+, stdenv
+, xcaddy
+}:
+
+{ plugins ? [ ]
+, vendorHash ? null
+}:
+
+stdenv.mkDerivation {
+  pname = "caddy-using-xcaddy-${xcaddy.version}";
+  inherit (caddy) version;
+
+  dontUnpack = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [
+    cacert
+    go
+  ];
+
+  configurePhase = ''
+    export GOCACHE="$TMPDIR/go-cache"
+    export GOPATH="$TMPDIR/go"
+    export XCADDY_SKIP_BUILD=1
+  '';
+
+  buildPhase = ''
+    ${lib.getExe xcaddy} build "${caddy.src.rev}" \
+      ${lib.concatMapStringsSep " \\\n  " (plugin: "--with ${plugin}") plugins}
+    cd buildenv*
+    go mod vendor
+  '';
+
+  installPhase = ''
+    cp -r --reflink=auto . "$out"
+  '';
+
+  outputHash = vendorHash;
+  outputHashMode = "recursive";
+}


### PR DESCRIPTION
This creates two new outputs and uses `caddy-extended` from here, _not_ from `spanx`.

1.  `fetchXCaddy` to fetch caddy source using `xcaddy` and `go mod vendor`.
2.  `caddyWith` to extend caddy.

Both take the following parameters (in an attrset).

-   `plugins`
-   `vendorHash`

Based on [nixos-config/packages/caddy/default.nix at f49eaf2f1deca07eb0dc76d0ae426c9651b1d446 · emilylange/nixos-config](https://github.com/emilylange/nixos-config/blob/f49eaf2f1deca07eb0dc76d0ae426c9651b1d446/packages/caddy/default.nix).
