### PR TITLE
(Attempt to) fix the vendor hash for caddy-extended

### DIFF
--- a/servers/caddy/caddy-extended.nix
+++ b/servers/caddy/caddy-extended.nix
@@ -7,5 +7,5 @@ caddyWith {
     "github.com/greenpau/caddy-security" = "8d00b5c2ae849b997a9faad47fab9f92dfd77b08";
     "github.com/lindenlab/caddy-s3-proxy" = "850db193cb7f48546439d236f2a6de7bd7436e2e";
   };
-  vendorHash = "sha256-y7iq9v2KDc5N5W4JRJtnVeG3CpjzlGAUYo3Qk0IkjFk=";
+  vendorHash = "sha256-TAPG66OdnPjsblcNb+M2KLMHhiLBBmbKb2Q6r51xTb4=";
 }

--- a/servers/caddy/caddy-extended.nix
+++ b/servers/caddy/caddy-extended.nix
@@ -4,7 +4,7 @@
 caddyWith {
   plugins = {
     "github.com/fore-stun/spanx" = "9e9109e6b964cd36fb9cb1be8328b0f32b3d60c3";
-    "github.com/greenpau/caddy-security" = "8d00b5c2ae849b997a9faad47fab9f92dfd77b08";
+    "github.com/greenpau/caddy-security" = "bdd7abe375e7b0c13e6233a2f9b5433ba69c6af9";
     "github.com/lindenlab/caddy-s3-proxy" = "850db193cb7f48546439d236f2a6de7bd7436e2e";
   };
   vendorHash = "sha256-TAPG66OdnPjsblcNb+M2KLMHhiLBBmbKb2Q6r51xTb4=";

--- a/servers/caddy/caddy-extended.nix
+++ b/servers/caddy/caddy-extended.nix
@@ -2,10 +2,10 @@
 }:
 
 caddyWith {
-  plugins = [
-    "github.com/fore-stun/spanx"
-    "github.com/greenpau/caddy-security"
-    "github.com/lindenlab/caddy-s3-proxy"
-  ];
+  plugins = {
+    "github.com/fore-stun/spanx" = "9e9109e6b964cd36fb9cb1be8328b0f32b3d60c3";
+    "github.com/greenpau/caddy-security" = "8d00b5c2ae849b997a9faad47fab9f92dfd77b08";
+    "github.com/lindenlab/caddy-s3-proxy" = "850db193cb7f48546439d236f2a6de7bd7436e2e";
+  };
   vendorHash = "sha256-y7iq9v2KDc5N5W4JRJtnVeG3CpjzlGAUYo3Qk0IkjFk=";
 }

--- a/servers/caddy/caddy-extended.nix
+++ b/servers/caddy/caddy-extended.nix
@@ -7,5 +7,5 @@ caddyWith {
     "github.com/greenpau/caddy-security" = "bdd7abe375e7b0c13e6233a2f9b5433ba69c6af9";
     "github.com/lindenlab/caddy-s3-proxy" = "850db193cb7f48546439d236f2a6de7bd7436e2e";
   };
-  vendorHash = "sha256-TAPG66OdnPjsblcNb+M2KLMHhiLBBmbKb2Q6r51xTb4=";
+  vendorHash = "sha256-qZjHioeL5xhX4xYt6hlSi7oG0DO8/pzSZ0WZSJRjSRo=";
 }

--- a/servers/caddy/fetchXCaddy.nix
+++ b/servers/caddy/fetchXCaddy.nix
@@ -6,9 +6,17 @@
 , xcaddy
 }:
 
-{ plugins ? [ ]
+{ plugins ? { }
 , hash ? null
 }:
+
+let
+  caddyPlugins = lib.concatMapStringsSep
+    " \\\n  "
+    ({ name, value }: "--with ${name}@${value}")
+    (lib.attrsToList plugins);
+
+in
 
 stdenv.mkDerivation {
   pname = "caddy-using-xcaddy-${xcaddy.version}";
@@ -30,7 +38,7 @@ stdenv.mkDerivation {
 
   buildPhase = ''
     ${lib.getExe xcaddy} build "${caddy.src.rev}" \
-      ${lib.concatMapStringsSep " \\\n  " (plugin: "--with ${plugin}") plugins}
+      ${caddyPlugins}
     cd buildenv*
     go mod vendor
   '';


### PR DESCRIPTION
Dependency versions need to be pinned. I'm not sure whether this is enough — I'm not suitably familiar with the reproducibility of go vendoring 🤔
