### PR TITLE
Implement derivation for rust-based wstunnel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709479366,
-        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
+        "lastModified": 1710806803,
+        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
+        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710886643,
+        "narHash": "sha256-saTZuv9YeZ9COHPuj8oedGdUwJZcbQ3vyRqe7NVJMsQ=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "5bace74e9a65165c918205cf67ad3977fe79c584",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -58,6 +78,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "gomod2nix": "gomod2nix",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,8 @@
       ./editors/language-server
       ./editors/formatter
 
+      ./network/tunnel
+
       ./utils/email
       ./utils/exif
       ./utils/generators

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,9 @@
     rust.inputs.nixpkgs.follows = "nixpkgs";
     rust.inputs.flake-utils.follows = "flake-utils";
 
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
+
     gomod2nix.url = "github:fore-stun/gomod2nix/fix-recursive-symlinker";
     gomod2nix.inputs.nixpkgs.follows = "nixpkgs";
     gomod2nix.inputs.flake-utils.follows = "flake-utils";

--- a/network/tunnel/default.nix
+++ b/network/tunnel/default.nix
@@ -1,4 +1,4 @@
-{ self, lib, nixpkgs, ... }:
+{ self, lib, nixpkgs, crane, ... }:
 
 let
   pnames = [
@@ -9,7 +9,9 @@ in
 {
   overlays.tunnel = final: prev:
     let
-      extras = { };
+      extras = {
+        wstunnel = { inherit crane; };
+      };
     in
     lib.foldFor pnames (pname: {
       ${pname} = lib.callPackageWith prev (./. + "/${pname}.nix") (

--- a/network/tunnel/default.nix
+++ b/network/tunnel/default.nix
@@ -1,0 +1,27 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [
+  ];
+
+in
+{
+  overlays.tunnel = final: prev:
+    let
+      extras = { };
+    in
+    lib.foldFor pnames (pname: {
+      ${pname} = lib.callPackageWith prev (./. + "/${pname}.nix") (
+        extras.${pname} or { }
+      );
+    });
+} //
+lib.foldFor lib.platforms.all (system: {
+  packages.${system} = lib.flip lib.filterAttrs self.legacyPackages.${system}
+    (n: a: builtins.elem n pnames && lib.isDerivation a);
+  legacyPackages.${system} = self.overlays.tunnel
+    self.legacyPackages.${system}
+    nixpkgs.legacyPackages.${system};
+})
+
+

--- a/network/tunnel/default.nix
+++ b/network/tunnel/default.nix
@@ -2,6 +2,7 @@
 
 let
   pnames = [
+    "wstunnel"
   ];
 
 in

--- a/network/tunnel/wstunnel.nix
+++ b/network/tunnel/wstunnel.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+}:
+
+let
+  pname = "wstunnel";
+  version = "9.2.4";
+  owner = "erebe";
+  repo = pname;
+
+  src = fetchFromGitHub {
+    inherit owner repo;
+    rev = "832e253b3cc8ed0c1215d18526911d106319d329";
+    hash = "sha256-BWJgw7YNdRMbNwb+s8NYc9QNUACD3QQbISB0h8eHJLg=";
+  };
+in
+rustPlatform.buildRustPackage {
+  inherit pname version src;
+
+  cargoHash = lib.fakeHash;
+  doCheck = false;
+
+  meta = {
+    description = "Tunnel all your traffic over Websocket or HTTP2 - Bypass firewalls/DPI - Static binary available Topics";
+    homepage = "https://github.com/${owner}/${repo}";
+    license = lib.licenses.bsd3;
+    mainProgram = pname;
+  };
+}

--- a/network/tunnel/wstunnel.nix
+++ b/network/tunnel/wstunnel.nix
@@ -1,6 +1,10 @@
 { lib
+, crane
+, darwin
 , fetchFromGitHub
-, rustPlatform
+, hostPlatform
+, libiconv
+, system
 }:
 
 let
@@ -9,16 +13,24 @@ let
   owner = "erebe";
   repo = pname;
 
+  clib = crane.lib.${system};
+
   src = fetchFromGitHub {
     inherit owner repo;
     rev = "832e253b3cc8ed0c1215d18526911d106319d329";
     hash = "sha256-BWJgw7YNdRMbNwb+s8NYc9QNUACD3QQbISB0h8eHJLg=";
   };
 in
-rustPlatform.buildRustPackage {
+clib.buildPackage {
   inherit pname version src;
 
-  cargoHash = lib.fakeHash;
+  nativeBuildInputs = [
+    libiconv
+  ] ++ lib.optionals hostPlatform.isDarwin [
+    darwin.apple_sdk.frameworks.CoreServices
+    darwin.apple_sdk.frameworks.Security
+  ];
+
   doCheck = false;
 
   meta = {


### PR DESCRIPTION
The tool was rewritten in rust, from haskell, for various reasons, and upstream nixpkgs doesn't yet support it. Given the need to use `crane` to build it, I'm not sure what would happen to have it available upstream.

Also this bumps nixpkgs.
