### PR TITLE
Fix caddy wrapper

### DIFF
--- a/servers/caddy/caddyWith.nix
+++ b/servers/caddy/caddyWith.nix
@@ -4,11 +4,11 @@
 , fetchXCaddy
 }:
 
+lib.fix (caddyWith:
 { plugins
 , vendorHash
 }:
-
-lib.fix (caddyWith: (
+(
   caddy.override {
     buildGoModule = args: buildGoModule (args // {
       src = fetchXCaddy {


### PR DESCRIPTION
Fix in two senses of the word.

1.  The wrapper, as passed through in `caddy-extended`, was incorrect…
2.  …because the fix point excluded the `plugins`/`vendorHash` argument.
