### PR TITLE
Add script to mount interactively on linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
       ./scripts/nix
       ./scripts/pandoc
       ./scripts/sync
+      ./scripts/system
       ./scripts/text
 
       ./servers/caddy

--- a/scripts/system/default.nix
+++ b/scripts/system/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ ];
+  pnames = [ "mount-interactive" ];
 in
 {
   overlays.system-script = final: prev: lib.foldFor pnames

--- a/scripts/system/mount-interactive.nix
+++ b/scripts/system/mount-interactive.nix
@@ -1,0 +1,47 @@
+{ lib
+, fzf
+, gawk
+, udisks
+, util-linuxMinimal
+, writers
+}:
+let
+  pname = "mount-interactive";
+  version = "0.1.0";
+  script = writers.writeZshBin "${pname}" ''
+    interactive_mount() {
+      local DEVICE
+      local MOUNTPOINT
+      ${util-linuxMinimal}/bin/lsblk -lnpb -o NAME,ID-LINK,MOUNTPOINT \
+        | ${fzf}/bin/fzf --reverse --ansi \
+          --preview-window=up,3 \
+          --preview='print -l -- {1} {2} {3}' \
+        | ${lib.getExe gawk} '{print $2, $3}' \
+        | { read -r DEVICE MOUNTPOINT || : }
+
+      if ! (( #DEVICE )); then
+        print -l -- "No device selected" >&2
+        return 0
+      fi
+
+      local CMD
+      if (( #MOUNTPOINT )); then
+        CMD="unmount"
+      else
+        CMD="mount"
+      fi
+
+      print -- "''${CMD}ing…" >&2
+
+      ${udisks}/bin/udisksctl "''${CMD}" -b "/dev/disk/by-id/''${DEVICE}"
+    }
+
+    interactive_mount
+  '';
+in
+lib.standalone {
+  inherit version script;
+  meta = {
+    platforms = lib.platforms.linux;
+  };
+}

--- a/utils/system/default.nix
+++ b/utils/system/default.nix
@@ -1,0 +1,19 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [ ];
+in
+{
+  overlays.system-script = final: prev: lib.foldFor pnames
+    (pname: {
+      ${pname} = prev.callPackage (./. + "/${pname}.nix") {
+        inherit (final) writers;
+        inherit lib;
+      };
+    });
+} //
+lib.foldFor lib.platforms.all (system: {
+  packages.${system} = self.overlays.system-script
+    self.legacyPackages.${system}
+    nixpkgs.legacyPackages.${system};
+})


### PR DESCRIPTION
This uses `lsblk` to identify the block devices, and then `udisks2` to mount/unmount depending on mount status.
