### PR TITLE
Export function to override python packages

### DIFF
--- a/dependencies/python/default.nix
+++ b/dependencies/python/default.nix
@@ -26,26 +26,9 @@ let
 
 in
 {
-  overlays.python = final: prev:
-    let
-      pythonPkgsScope = prev.python3.pkgs.overrideScope (prev.lib.composeManyExtensions [
-        (_: _: newPackages final prev)
-      ]);
-    in
-    {
-      python3 = prev.python3 // {
-        pkgs = pythonPkgsScope;
-        withPackages = f: prev.python3.buildEnv.override { extraLibs = f pythonPkgsScope; };
-
-        packageOverrides = lib.warn ''
-          `python3.packageOverrides` does not compose;
-          instead, manually replace the `pkgs` attr of `python3` with `python3.pkgs.overrideScope` applied to the overrides.
-        ''
-          prev.python3.packageOverrides;
-      };
-
-      python3Packages = pythonPkgsScope;
-    };
+  overlays.python = final: prev: lib.pythonScopeWith prev "3" [
+    (_: _: newPackages final prev)
+  ];
 
 } //
 lib.foldFor lib.platforms.all (system: {

--- a/dependencies/python/default.nix
+++ b/dependencies/python/default.nix
@@ -35,6 +35,7 @@ in
     {
       python3 = prev.python3 // {
         pkgs = pythonPkgsScope;
+        withPackages = f: prev.python3.buildEnv.override { extraLibs = f pythonPkgsScope; };
 
         packageOverrides = lib.warn ''
           `python3.packageOverrides` does not compose;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -23,11 +23,31 @@ let
       passthru = old.passthru or { } // passthru;
     });
 
+  pythonScopeWith = prev: pythonVariant: overlays:
+    let
+      python3 = prev."python${pythonVariant}";
+      pkgs = python3.pkgs.overrideScope (lib.composeManyExtensions overlays);
+    in
+    {
+      "python${pythonVariant}" = python3 // {
+        inherit pkgs;
+        withPackages = f: python3.buildEnv.override { extraLibs = f pkgs; };
+
+        packageOverrides = lib.warn ''
+          `python3.packageOverrides` does not compose;
+          instead, manually replace the `pkgs` attr of `python3` with `python3.pkgs.overrideScope` applied to the overrides.
+        ''
+          prev.python3.packageOverrides;
+      };
+      "python${pythonVariant}Packages" = pkgs;
+    };
+
 in
 lib.recursiveUpdate lib {
   platforms = { inherit anyNix; };
   licenses = { inherit dual; };
   inherit
     standalone
+    pythonScopeWith
     ;
 }


### PR DESCRIPTION
The `packageOverrides` option is not composable.
This form, using `overrideScope`, is.
