### PR TITLE
Add handbrake binaries on darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,8 @@
       ./editors/language-server
       ./editors/formatter
 
+      ./media/video
+
       ./network/tunnel
 
       ./utils/email

--- a/media/video/default.nix
+++ b/media/video/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ "handbrake-gui-bin" ];
+  pnames = [ "handbrake-cli-bin" "handbrake-gui-bin" ];
 in
 {
   overlays.video = final: prev:

--- a/media/video/default.nix
+++ b/media/video/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ ];
+  pnames = [ "handbrake-gui-bin" ];
 in
 {
   overlays.video = final: prev:

--- a/media/video/default.nix
+++ b/media/video/default.nix
@@ -1,12 +1,16 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ "handbrake-cli-bin" "handbrake-gui-bin" ];
+  pnames = [ "handbrake-bin" "handbrake-cli-bin" "handbrake-gui-bin" ];
 in
 {
   overlays.video = final: prev:
     let
-      extras = { };
+      extras = {
+        "handbrake-bin" = {
+          inherit (final) handbrake-cli-bin handbrake-gui-bin;
+        };
+      };
     in
     lib.foldFor pnames
       (pname: {

--- a/media/video/default.nix
+++ b/media/video/default.nix
@@ -1,0 +1,28 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [ ];
+in
+{
+  overlays.video = final: prev:
+    let
+      extras = { };
+    in
+    lib.foldFor pnames
+      (pname: {
+        ${pname} = prev.callPackage
+          (./. + "/${pname}.nix")
+          (extras."${pname}" or { });
+      });
+} //
+lib.foldFor lib.platforms.all (system:
+  let
+    pkgs = nixpkgs.legacyPackages.${system};
+  in
+  {
+    packages.${system} =
+      lib.filterAttrs (_: lib.isDerivation) self.legacyPackages.${system};
+    legacyPackages.${system} = self.overlays.video
+      (pkgs // self.packages.${system})
+      pkgs;
+  })

--- a/media/video/handbrake-bin.nix
+++ b/media/video/handbrake-bin.nix
@@ -1,0 +1,21 @@
+{ lib
+, handbrake-cli-bin
+, handbrake-gui-bin
+, handbrake
+, symlinkJoin
+}:
+
+let
+
+  inherit (handbrake) pname;
+  inherit (handbrake-cli-bin) meta;
+  version = "1.8.2";
+
+in
+symlinkJoin {
+  name = "${pname}-${version}";
+  inherit pname version meta;
+  buildInputs = [ ];
+
+  paths = [ handbrake-cli-bin handbrake-gui-bin ];
+}

--- a/media/video/handbrake-cli-bin.nix
+++ b/media/video/handbrake-cli-bin.nix
@@ -1,0 +1,50 @@
+{ lib
+, darwin
+, fetchurl
+, hostPlatform
+, handbrake
+, stdenvNoCC
+, undmg
+}:
+
+let
+
+  inherit (handbrake) pname meta;
+  version = "1.8.2";
+
+  src = let name = "${pname}-${version}.dmg"; in
+    fetchurl
+      {
+        inherit name;
+        urls = [
+          "https://github.com/HandBrake/HandBrake/releases/download/${version}/HandBrakeCLI-${version}.dmg"
+        ];
+        hash = "sha256-Tfw9cO9bYMhv2MrIfiF062usMqAfnD6cXiLzyxImRsU=";
+      };
+
+  handbrakeCliBin = stdenvNoCC.mkDerivation {
+    pname = "${pname}-cli";
+    inherit src version;
+    sourceRoot = ".";
+
+    meta = meta // {
+      platforms = lib.platforms.darwin;
+      broken = false;
+      mainProgram = "HandBrakeCLI";
+    };
+
+    nativeBuildInputs = [
+      undmg
+    ];
+
+    installPhase = ''
+      mkdir -p "$out/bin"
+      cp -pR "HandBrakeCLI" "$out/bin/"
+
+      mkdir -p "$out/share/"
+      cp -pR "doc" "$out/share/"
+    '';
+  };
+
+in
+handbrakeCliBin

--- a/media/video/handbrake-gui-bin.nix
+++ b/media/video/handbrake-gui-bin.nix
@@ -1,0 +1,46 @@
+{ lib
+, darwin
+, fetchurl
+, hostPlatform
+, handbrake
+, stdenvNoCC
+, undmg
+}:
+
+let
+
+  inherit (handbrake) pname meta;
+  version = "1.8.2";
+
+  src = let name = "${pname}-${version}.dmg"; in
+    fetchurl
+      {
+        inherit name;
+        urls = [
+          "https://github.com/HandBrake/HandBrake/releases/download/${version}/HandBrake-${version}.dmg"
+        ];
+        hash = "sha256-pZ3Ba2qmzlBBZyYgs+6+LlG7MgXkvQpWI1nL8TI7LYQ=";
+      };
+
+  handbrakeBin = stdenvNoCC.mkDerivation {
+    pname = "${pname}-gui";
+    inherit src version;
+    sourceRoot = ".";
+
+    meta = meta // {
+      platforms = lib.platforms.darwin;
+      broken = false;
+    };
+
+    nativeBuildInputs = [
+      undmg
+    ];
+
+    installPhase = ''
+      mkdir -p "$out/Applications/"
+      cp -pR "HandBrake.app" "$out/Applications/"
+    '';
+  };
+
+in
+handbrakeBin


### PR DESCRIPTION
Handbrake builds are blocked, currently, as per [handbrake: 1.6.1 -> 1.7.3 by uninsane · Pull Request #297984 · NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/pull/297984#issuecomment-2016503434).
(`metal` is needed for the build.)

This creates three derivations.

1.  Handbrake combined CLI and GUI.
2.  Handbrake GUI.
3.  Handbrake CLI.
