### PR TITLE
Extend caddy with dns plugins

### DIFF
--- a/servers/caddy/caddy-extended.nix
+++ b/servers/caddy/caddy-extended.nix
@@ -3,9 +3,13 @@
 
 caddyWith {
   plugins = {
+    # Caddy dns
+    "github.com/caddy-dns/cloudflare" = "89f16b99c18ef49c8bb470a82f895bce01cbaece";
+    "github.com/caddy-dns/route53" = "d92230e22b716e9b0c8bc1086477415f8b90e77f";
+
     "github.com/fore-stun/spanx" = "9e9109e6b964cd36fb9cb1be8328b0f32b3d60c3";
     "github.com/greenpau/caddy-security" = "bdd7abe375e7b0c13e6233a2f9b5433ba69c6af9";
     "github.com/lindenlab/caddy-s3-proxy" = "850db193cb7f48546439d236f2a6de7bd7436e2e";
   };
-  vendorHash = "sha256-yKgE2IzuCD5CzoQ76YwBhh0wAKY8vHa1wjYoK5UWoCE=";
+  vendorHash = "sha256-helrpqlDIjajZ3DtJGZaEoKWrNoj0KXGYRYKnxoObQM=";
 }

--- a/servers/caddy/caddyWith.nix
+++ b/servers/caddy/caddyWith.nix
@@ -6,7 +6,7 @@
 
 lib.fix (caddyWith:
 { plugins
-, vendorHash
+, vendorHash ? lib.fakeHash
 }:
 (
   caddy.override {


### PR DESCRIPTION
For cloudflare and route53.

Also simplify updates with a default `lib.fakehash` for the `vendorHash`.
