### PR TITLE
Fix shell use of stdin

### DIFF
--- a/scripts/pandoc/simple-markdown.nix
+++ b/scripts/pandoc/simple-markdown.nix
@@ -142,7 +142,7 @@ let
       local PANDOC_EXTRA_SIGIL=(--pandoc-extra-arg -P)
       PANDOC_ARGS+=("''${(@)pandoc_extra:|PANDOC_EXTRA_SIGIL}")
 
-      ${pandoc}/bin/pandoc "''${(@)PANDOC_ARGS}" </dev/stdin
+      ${pandoc}/bin/pandoc "''${(@)PANDOC_ARGS}" <&0
     }
 
     convertPandoc "$@"


### PR DESCRIPTION
It should use `<&0` rather than `</dev/stdin`.

The breakage causes issues when called from `vim.system`, for example.
