### PR TITLE
Add lang library function

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,6 +1,8 @@
 { lib, ... }:
 
 let
+  lang = l: x: x;
+
   anyNix = lib.platforms.darwin ++ lib.platforms.linux;
 
   dual = builtins.attrValues
@@ -47,6 +49,7 @@ lib.recursiveUpdate lib {
   platforms = { inherit anyNix; };
   licenses = { inherit dual; };
   inherit
+    lang
     standalone
     pythonScopeWith
     ;


### PR DESCRIPTION
This is useful for nested nix highlighting: call `lang "${LANGUAGE?}" '' ''` and the text can be matched with tree-sitter (`@injection.content`) with the `"${LANGUAGE?}"` as `@injection.language`.
