### PR TITLE
Add fusuma-plugin-sendkey

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,7 @@
       ./utils/generators
       ./utils/shell
       ./utils/writers
+      ./utils/wayland
 
       ./scripts/darwin
       ./scripts/nix

--- a/utils/wayland/default.nix
+++ b/utils/wayland/default.nix
@@ -1,7 +1,7 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ ];
+  pnames = [ "fusuma-plugin-sendkey" ];
 in
 {
   overlays.storage = final: prev:

--- a/utils/wayland/default.nix
+++ b/utils/wayland/default.nix
@@ -1,0 +1,21 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [ ];
+in
+{
+  overlays.storage = final: prev:
+    let
+      extras = { };
+    in
+    lib.foldFor pnames (pname: {
+      ${pname} = prev.callPackage
+        (./. + "/${pname}.nix")
+        (extras."${pname}" or { });
+    });
+} //
+lib.foldFor lib.platforms.all (system: {
+  packages.${system} = self.overlays.storage
+    (nixpkgs.legacyPackages.${system} // self.packages.${system})
+    nixpkgs.legacyPackages.${system};
+})

--- a/utils/wayland/fusuma-plugin-sendkey.nix
+++ b/utils/wayland/fusuma-plugin-sendkey.nix
@@ -1,0 +1,41 @@
+{ lib
+, bundlerApp
+, gnugrep
+, libinput
+, makeWrapper
+}:
+
+let
+  pname = "fusuma-plugin-sendkey";
+  owner = "iberianpig";
+
+  mainProgram = "fusuma-sendkey";
+
+  repo = pname;
+
+in
+bundlerApp {
+  inherit pname;
+
+  gemdir = builtins.path {
+    name = pname;
+    path = ./. + "/${pname}";
+  };
+
+  exes = [ mainProgram ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram "$out/bin/${mainProgram}" \
+      --prefix PATH : ${lib.makeBinPath [ gnugrep libinput ]}
+  '';
+
+  meta = {
+    description = "A Fusuma plugin for sending virtual key events";
+    homepage = "https://github.com/${owner}/${repo}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    inherit mainProgram;
+  };
+}

--- a/utils/wayland/fusuma-plugin-sendkey/Gemfile
+++ b/utils/wayland/fusuma-plugin-sendkey/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem "fusuma-plugin-sendkey", "0.13.2"

--- a/utils/wayland/fusuma-plugin-sendkey/Gemfile.lock
+++ b/utils/wayland/fusuma-plugin-sendkey/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    fusuma (3.6.2)
+    fusuma-plugin-sendkey (0.13.2)
+      fusuma (>= 3.1)
+      revdev
+    revdev (0.2.1)
+
+PLATFORMS
+  aarch64-linux
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  fusuma-plugin-sendkey (= 0.13.2)
+
+BUNDLED WITH
+   2.5.16

--- a/utils/wayland/fusuma-plugin-sendkey/gemset.nix
+++ b/utils/wayland/fusuma-plugin-sendkey/gemset.nix
@@ -1,0 +1,33 @@
+{
+  fusuma = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "185dfdni1gv139l02x7pjdi0p1x58izp93i2953s26z09x8s8xly";
+      type = "gem";
+    };
+    version = "3.6.2";
+  };
+  fusuma-plugin-sendkey = {
+    dependencies = ["fusuma" "revdev"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "136wi4mn6rh3zwpcafwbdmzrqlf39ird1n1y1lakq4irx6cnicpn";
+      type = "gem";
+    };
+    version = "0.13.2";
+  };
+  revdev = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1b6zg6vqlaik13fqxxcxhd4qnkfgdjnl4wy3a1q67281bl0qpsz9";
+      type = "gem";
+    };
+    version = "0.2.1";
+  };
+}


### PR DESCRIPTION
The plugin is included in nixpkgs.

However, the executable is not — that is available here. It can be used to test keys.

Really, this should be available upstream, as part of the fusuma package. When I make that PR, I'll remove this.
