### PR TITLE
Add jj-scripts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,7 @@
       ./utils/wayland
 
       ./scripts/darwin
+      ./scripts/jujutsu
       ./scripts/nix
       ./scripts/pandoc
       ./scripts/sync

--- a/scripts/jujutsu/default.nix
+++ b/scripts/jujutsu/default.nix
@@ -2,6 +2,7 @@
 
 let
   pnames = [
+    "jj-scripts"
   ];
 in
 {

--- a/scripts/jujutsu/default.nix
+++ b/scripts/jujutsu/default.nix
@@ -1,0 +1,21 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [
+  ];
+in
+{
+  overlays.jujutsu-script = final: prev: lib.foldFor pnames (pname: {
+    ${pname} = prev.callPackage (./. + "/${pname}.nix") {
+      inherit (final) writers;
+      inherit lib;
+    };
+  });
+} //
+lib.foldFor lib.platforms.all (system:
+  {
+    packages.${system} = self.overlays.jujutsu-script
+      self.legacyPackages.${system}
+      nixpkgs.legacyPackages.${system};
+  }
+)

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -3,6 +3,7 @@
 , findutils
 , fzf
 , gawk
+, gh
 , jujutsu
 , moreutils
 , writers
@@ -126,6 +127,19 @@ let
       IGNOREHEAD
 
         ${lib.getExe jujutsu} new
+    '';
+
+    gh-merge = indent ''
+      local TIP
+      ${lib.getExe jujutsu} bookmark list -r "heads(::@- & bookmarks())" -T "name" \
+        | { read -r TIP || : }
+
+      ${lib.getExe gh} pr merge -m "''${TIP}" \
+        && ${lib.getExe jujutsu} bookmark delete "''${TIP}" \
+        && ${lib.getExe jujutsu} git fetch \
+        && ${lib.getExe jujutsu} rebase -r "at_operation(@-,trunk()):: ~ ::trunk()" -d "trunk()"  \
+        && ${lib.getExe jujutsu} git push --tracked \
+        && ${lib.getExe jujutsu} new "trunk()"
     '';
   };
 

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -1,0 +1,51 @@
+{ lib
+, writers
+}:
+let
+  pname = "jj-scripts";
+  version = "0.1.0";
+
+  functions = { };
+
+  wrapFunctions =
+    let
+      f = name: inner:
+        let fname = "_jj_${lib.replaceStrings ["-"] ["_"] name}";
+        in ''
+          renamed[${name}]="${fname}"
+          ${fname}() {
+          ${inner}
+          }
+        '';
+    in
+    lib.flip lib.pipe [
+      (lib.mapAttrsToList f)
+      (lib.concatStringsSep "\n\n")
+    ];
+
+  script = writers.writeZshBin "${pname}" ''
+    typeset -A renamed
+
+    ${wrapFunctions functions}
+    function help() {
+      echo "${pname} functions:"
+      echo "> ''${(@)subcommands}"
+    }
+
+    local -a subcommands
+    subcommands=(''${(k)functions:#_*} ''${(k)renamed})
+
+    if [ $# -ge 1 ] && grep -q "$1" <<< "''${(@)subcommands}"
+    then
+      "''${renamed[(e)$1]:-$1}" "$@[2,-1]"
+      exit 0
+    else
+      echo "Not a ${pname} sub-command: $1" >&2
+      exit 2
+    fi
+  '';
+
+in
+lib.standalone {
+  inherit version script;
+}

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -167,7 +167,15 @@ let
     fi
   '';
 
+
+in
+lib.fix (this:
+let
+  mkAlias = n: _: [ "util" "exec" "--" "${lib.getExe this}" "${n}" ];
 in
 lib.standalone {
   inherit version script;
-}
+  passthru = {
+    aliases = lib.mapAttrs mkAlias functions;
+  };
+})


### PR DESCRIPTION
Some helper functions.

Use `jj-scripts.aliases` in the jujutsu config file to add aliases.

Currently adds the following interactive tools (with fzf).

-   track-bookmarks
-   delete-bookmarks
-   op-restore
-   evolog-check

The following commits a set of changes and then adds the commit hash to `.git-blame-ignore-revs`

-   noblame
