### PR TITLE
Extend jj-scripts

### DIFF
--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -158,6 +158,14 @@ let
       ${lib.getExe gh} pr create -H "''${CURRENT_BOOKMARK}" "$@"
     '';
 
+    gh-pr-view = indent ''
+      local TIP
+      ${lib.getExe jujutsu} bookmark list -r "heads(::@- & bookmarks())" -T "name" \
+        | { read -r TIP || : }
+
+      ${lib.getExe gh} pr view --web "''${TIP}"
+    '';
+
     merge-trunk = indent ''
       local BRANCH="''${1?Branch name}"
       ${lib.getExe jujutsu} bookmark delete "@-" 2>/dev/null || :

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -141,6 +141,14 @@ let
         && ${lib.getExe jujutsu} git push --tracked \
         && ${lib.getExe jujutsu} new "trunk()"
     '';
+
+    merge-trunk = indent ''
+      local BRANCH="''${1?Branch name}"
+      ${lib.getExe jujutsu} bookmark delete "@-" 2>/dev/null || :
+      ${lib.getExe jujutsu} new "trunk()" "@-" -m "Merge branch ''\'''${BRANCH}'" \
+        && ${lib.getExe jujutsu} new \
+        && ${lib.getExe jujutsu} bookmark move --from "heads(::@- & bookmarks())" --to "@-"
+    '';
   };
 
   wrapFunctions =

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -142,6 +142,22 @@ let
         && ${lib.getExe jujutsu} new "trunk()"
     '';
 
+    gh-pr-create = indent ''
+      local CURRENT_BOOKMARK
+      ${lib.getExe jujutsu} bookmark list -r "@-" -T "name" \
+        | { read -r CURRENT_BOOKMARK || : }
+
+      if (( #CURRENT_BOOKMARK )); then
+        ${lib.getExe jujutsu} git push -b "''${CURRENT_BOOKMARK}"
+      else
+        ${lib.getExe jujutsu} git push -c "@-"
+        ${lib.getExe jujutsu} bookmark list -r "@-" -T "name" \
+          | { read -r CURRENT_BOOKMARK || : }
+      fi
+
+      ${lib.getExe gh} pr create -H "''${CURRENT_BOOKMARK}" "$@"
+    '';
+
     merge-trunk = indent ''
       local BRANCH="''${1?Branch name}"
       ${lib.getExe jujutsu} bookmark delete "@-" 2>/dev/null || :

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -129,7 +129,7 @@ let
         ${lib.getExe jujutsu} new
     '';
 
-    gh-merge = indent ''
+    gh-pr-merge = indent ''
       local TIP
       ${lib.getExe jujutsu} bookmark list -r "heads(::@- & bookmarks())" -T "name" \
         | { read -r TIP || : }


### PR DESCRIPTION
Some more helper functions.

Use `jj-scripts.aliases` in the jujutsu config file to add aliases.

Adds the following github helpers

-   gh-pr-create
-   gh-pr-view
-   gh-pr-merge (renamed from gh-merge)

Adds the following merge helper

-   merge-trunk
