### PR TITLE
Fix jj gh-pr-create for existing bookmarks

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,7 @@
 
 # Adjust bundled plugin expression
 2543a1923efad324627e5aa08f32e58b77db6f43
+
+# Indent for bookmark list template
+# orouzzrwoylvmvnwpvxlwlxnzspzynuw
+de54900b4afeb61332f44e9e306d7b105632bc44

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -187,20 +187,21 @@ let
         && ${lib.getExe jujutsu} new "trunk()"
     '';
 
-    gh-pr-create = indent ''
-      local CURRENT_BOOKMARK
-      ${lib.getExe jujutsu} bookmark list -r "@-" -T "name" \
-        | { read -r CURRENT_BOOKMARK || : }
+    gh-pr-create = ''
+        local CURRENT_BOOKMARK
 
-      if (( #CURRENT_BOOKMARK )); then
-        ${lib.getExe jujutsu} git push -b "''${CURRENT_BOOKMARK}"
-      else
-        ${lib.getExe jujutsu} git push -c "@-"
         ${lib.getExe jujutsu} bookmark list -r "@-" -T "name" \
           | { read -r CURRENT_BOOKMARK || : }
-      fi
 
-      ${lib.getExe gh} pr create -H "''${CURRENT_BOOKMARK}" "$@"
+        if (( #CURRENT_BOOKMARK )); then
+          ${lib.getExe jujutsu} git push -b "''${CURRENT_BOOKMARK}"
+        else
+          ${lib.getExe jujutsu} git push -c "@-"
+          ${lib.getExe jujutsu} bookmark list -r "@-" -T "name" \
+            | { read -r CURRENT_BOOKMARK || : }
+        fi
+
+        ${lib.getExe gh} pr create -H "''${CURRENT_BOOKMARK}" "$@"
     '';
 
     gh-pr-view = indent ''

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -188,9 +188,14 @@ let
     '';
 
     gh-pr-create = ''
+        local BOOKMARK_TEMPLATE
         local CURRENT_BOOKMARK
 
-        ${lib.getExe jujutsu} bookmark list -r "@-" -T "name" \
+        read -r BOOKMARK_TEMPLATE <<-'JJT' || :
+      name
+      JJT
+
+        ${lib.getExe jujutsu} bookmark list -r "@-" -T "''${BOOKMARK_TEMPLATE}" --no-pager \
           | { read -r CURRENT_BOOKMARK || : }
 
         if (( #CURRENT_BOOKMARK )); then
@@ -206,7 +211,8 @@ let
 
     gh-pr-view = indent ''
       local TIP
-      ${lib.getExe jujutsu} bookmark list -r "heads(::@- & bookmarks())" -T "name" \
+      ${lib.getExe jujutsu} bookmark list -r "heads(::@- & bookmarks())" \
+          -T "''${BOOKMARK_TEMPLATE}" --no-pager \
         | { read -r TIP || : }
 
       ${lib.getExe gh} pr view --web "''${TIP}"

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -192,7 +192,7 @@ let
         local CURRENT_BOOKMARK
 
         read -r BOOKMARK_TEMPLATE <<-'JJT' || :
-      name
+      if(remote, "", name)
       JJT
 
         ${lib.getExe jujutsu} bookmark list -r "@-" -T "''${BOOKMARK_TEMPLATE}" --no-pager \


### PR DESCRIPTION
The branch name was doubled up as both the local and remote bookmarks contributed a copy.
With this change, only a local bookmark will be non-empty.
