### PR TITLE
Re-introduce tailscale-nginx-auth, for darwin

### DIFF
--- a/servers/caddy/default.nix
+++ b/servers/caddy/default.nix
@@ -1,7 +1,16 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ "caddy-extended" ];
+  pnames = [ "caddy-extended" "tailscale-nginx-auth" ];
+
+  forAarch64Linux = pkgs: drv: (drv.override {
+    inherit (pkgs.pkgsCross.aarch64-multiplatform-musl) hostPlatform;
+    aarch64-linux = true;
+  }).overrideAttrs (old: {
+    GOOS = "linux";
+    GOARCH = "arm64";
+    CGO_ENABLED = false;
+  });
 
 in
 {
@@ -24,7 +33,10 @@ lib.foldFor lib.platforms.all (system:
   in
   {
     packages.${system} =
-      lib.filterAttrs (_: lib.isDerivation) self.legacyPackages.${system};
+      lib.filterAttrs (_: lib.isDerivation) self.legacyPackages.${system} // {
+        tailscale-nginx-auth-aarch64-linux =
+          forAarch64Linux pkgs self.packages.${system}.tailscale-nginx-auth;
+      };
     legacyPackages.${system} = self.overlays.caddy
       self.legacyPackages.${system}
       pkgs;

--- a/servers/caddy/default.nix
+++ b/servers/caddy/default.nix
@@ -4,7 +4,7 @@ let
   pnames = [ "caddy-extended" "tailscale-nginx-auth" ];
 
   forAarch64Linux = pkgs: drv: (drv.override {
-    inherit (pkgs.pkgsCross.aarch64-multiplatform-musl) hostPlatform;
+    inherit (pkgs.pkgsCross.aarch64-multiplatform-musl) stdenv;
     aarch64-linux = true;
   }).overrideAttrs (old: {
     GOOS = "linux";

--- a/servers/caddy/tailscale-nginx-auth.nix
+++ b/servers/caddy/tailscale-nginx-auth.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, hostPlatform
+, aarch64-linux ? false
+}:
+
+let
+  pname = "tailscale-nginx-auth";
+  version = "0.1.0";
+  src = fetchFromGitHub {
+    name = "${pname}-${version}-src";
+    owner = "tailscale";
+    repo = "tailscale";
+    rev = "a353ae079b8b0c5205278585c8c0a42ba00185a6";
+    hash = "sha256-OntCgV5vQig5neCaKvKXJKK1FiwcmrdilE+qTdsVn1I=";
+  };
+
+in
+buildGoModule {
+  inherit pname version src;
+
+  subPackages = [ "cmd/nginx-auth" ];
+
+  vendorHash = "sha256-l2uIma2oEdSN0zVo9BOFJF2gC3S60vXwTLVadv8yQPo=";
+
+  patches = [
+    (builtins.path {
+      name = "${pname}.patch";
+      path = ./${pname}.patch;
+    })
+  ];
+
+  CGO_ENABLED = 0;
+  doCheck = false;
+
+  preInstall = lib.optionalString aarch64-linux ''
+    mkdir -p "$out/bin"
+    dir="$GOPATH/bin"
+    [ -e "$dir" ] && mv -v "$dir/linux_arm64/"* "$dir/"
+    rm -rv "$dir/linux_arm64/"
+  '';
+
+  postInstall = lib.optionalString hostPlatform.isLinux ''
+    mkdir -p "$out/lib/systemd/system"
+
+    install -D -m0444 -t "$out/lib/systemd/system" \
+      "$src/cmd/nginx-auth/tailscale.nginx-auth.service"
+    install -D -m0444 -t "$out/lib/systemd/system" \
+      "$src/cmd/nginx-auth/tailscale.nginx-auth.socket"
+
+    sed -i -e "s#/usr/sbin#$out/bin#" "$out/lib/systemd/system/tailscale.nginx-auth.service"
+    sed -i -e "s#/var/run/#/run/#" "$out/lib/systemd/system/tailscale.nginx-auth.socket"
+  '' + lib.optionalString hostPlatform.isDarwin ''
+    mkdir -p "$out/Library/LaunchAgents"
+    cp ${./tailscale-nginx-auth.plist} "$out/Library/LaunchAgents/org.nixos.tailscale.nginx-auth.plist"
+    substituteInPlace $out/Library/LaunchAgents/org.nixos.tailscale.nginx-auth.plist --subst-var out
+  '' + ''
+    for i in "$out/bin/"*; do
+      ln -sv "$i" "$out/bin/tailscale.''${i##*/}"
+    done
+  '';
+
+  meta = {
+    description = "Use Tailscale Whois authentication with NGINX/Caddy as a reverse proxy";
+    license = lib.licenses.bsd3;
+    mainProgram = pname;
+  };
+}

--- a/servers/caddy/tailscale-nginx-auth.nix
+++ b/servers/caddy/tailscale-nginx-auth.nix
@@ -1,69 +1,48 @@
 { lib
-, buildGoModule
-, fetchFromGitHub
-, hostPlatform
+, tailscale-nginx-auth
+, stdenv
 , aarch64-linux ? false
 }:
 
 let
   pname = "tailscale-nginx-auth";
-  version = "0.1.0";
-  src = fetchFromGitHub {
-    name = "${pname}-${version}-src";
-    owner = "tailscale";
-    repo = "tailscale";
-    rev = "a353ae079b8b0c5205278585c8c0a42ba00185a6";
-    hash = "sha256-OntCgV5vQig5neCaKvKXJKK1FiwcmrdilE+qTdsVn1I=";
+
+  overriding = old: {
+    patches = [
+      (builtins.path {
+        name = "${pname}.patch";
+        path = ./${pname}.patch;
+      })
+    ];
+
+    preInstall = lib.optionalString aarch64-linux ''
+      mkdir -p "$out/bin"
+      dir="$GOPATH/bin"
+      [ -e "$dir" ] && mv -v "$dir/linux_arm64/"* "$dir/"
+      rm -rv "$dir/linux_arm64/"
+    '';
+
+    postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+      mkdir -p "$out/lib/systemd/system"
+
+      install -D -m0444 -t "$out/lib/systemd/system" \
+        "$src/cmd/nginx-auth/tailscale.nginx-auth.service"
+      install -D -m0444 -t "$out/lib/systemd/system" \
+        "$src/cmd/nginx-auth/tailscale.nginx-auth.socket"
+
+      sed -i -e "s#/usr/sbin#$out/bin#" "$out/lib/systemd/system/tailscale.nginx-auth.service"
+      sed -i -e "s#/var/run/#/run/#" "$out/lib/systemd/system/tailscale.nginx-auth.socket"
+    '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p "$out/Library/LaunchAgents"
+      cp ${./tailscale-nginx-auth.plist} "$out/Library/LaunchAgents/org.nixos.tailscale.nginx-auth.plist"
+      substituteInPlace $out/Library/LaunchAgents/org.nixos.tailscale.nginx-auth.plist --subst-var out
+    '' + ''
+      for i in "$out/bin/"*; do
+        ln -sv "$i" "$out/bin/tailscale.''${i##*/}"
+      done
+    '';
+
   };
 
 in
-buildGoModule {
-  inherit pname version src;
-
-  subPackages = [ "cmd/nginx-auth" ];
-
-  vendorHash = "sha256-l2uIma2oEdSN0zVo9BOFJF2gC3S60vXwTLVadv8yQPo=";
-
-  patches = [
-    (builtins.path {
-      name = "${pname}.patch";
-      path = ./${pname}.patch;
-    })
-  ];
-
-  CGO_ENABLED = 0;
-  doCheck = false;
-
-  preInstall = lib.optionalString aarch64-linux ''
-    mkdir -p "$out/bin"
-    dir="$GOPATH/bin"
-    [ -e "$dir" ] && mv -v "$dir/linux_arm64/"* "$dir/"
-    rm -rv "$dir/linux_arm64/"
-  '';
-
-  postInstall = lib.optionalString hostPlatform.isLinux ''
-    mkdir -p "$out/lib/systemd/system"
-
-    install -D -m0444 -t "$out/lib/systemd/system" \
-      "$src/cmd/nginx-auth/tailscale.nginx-auth.service"
-    install -D -m0444 -t "$out/lib/systemd/system" \
-      "$src/cmd/nginx-auth/tailscale.nginx-auth.socket"
-
-    sed -i -e "s#/usr/sbin#$out/bin#" "$out/lib/systemd/system/tailscale.nginx-auth.service"
-    sed -i -e "s#/var/run/#/run/#" "$out/lib/systemd/system/tailscale.nginx-auth.socket"
-  '' + lib.optionalString hostPlatform.isDarwin ''
-    mkdir -p "$out/Library/LaunchAgents"
-    cp ${./tailscale-nginx-auth.plist} "$out/Library/LaunchAgents/org.nixos.tailscale.nginx-auth.plist"
-    substituteInPlace $out/Library/LaunchAgents/org.nixos.tailscale.nginx-auth.plist --subst-var out
-  '' + ''
-    for i in "$out/bin/"*; do
-      ln -sv "$i" "$out/bin/tailscale.''${i##*/}"
-    done
-  '';
-
-  meta = {
-    description = "Use Tailscale Whois authentication with NGINX/Caddy as a reverse proxy";
-    license = lib.licenses.bsd3;
-    mainProgram = pname;
-  };
-}
+tailscale-nginx-auth.overrideAttrs overriding

--- a/servers/caddy/tailscale-nginx-auth.patch
+++ b/servers/caddy/tailscale-nginx-auth.patch
@@ -1,0 +1,13 @@
+diff --git i/cmd/nginx-auth/nginx-auth.go w/cmd/nginx-auth/nginx-auth.go
+index 09da74da..9770404a 100644
+--- i/cmd/nginx-auth/nginx-auth.go
++++ w/cmd/nginx-auth/nginx-auth.go
+@@ -1,7 +1,7 @@
+ // Copyright (c) Tailscale Inc & AUTHORS
+ // SPDX-License-Identifier: BSD-3-Clause
+ 
+-//go:build linux
++//go:build unix
+ 
+ // Command nginx-auth is a tool that allows users to use Tailscale Whois
+ // authentication with NGINX as a reverse proxy. This allows users that

--- a/servers/caddy/tailscale-nginx-auth.plist
+++ b/servers/caddy/tailscale-nginx-auth.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>org.nixos.tailscale.nginx-auth</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@out@/bin/tailscale.nginx-auth</string>
+  </array>
+  <key>KeepAlive</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>LaunchOnlyOnce</key>
+  <true/>
+  <key>Sockets</key>
+  <dict>
+    <key>ListenStream</key>
+    <dict>
+      <key>SockNodeName</key>
+      <string>/var/run/tailscale.nginx-auth.sock</string>
+    </dict>
+  </dict>
+  <key>ServiceIPC</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Upstream is configured for linux, only.
I restored the version removed 5 months ago in #83, and then simplified the code to take advantage of the upstream version.

As a result, this now works on darwin.
