### PR TITLE
Delete bookmarks on pr merge

### DIFF
--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -192,7 +192,7 @@ let
         && ${lib.getExe jujutsu} bookmark delete "''${TIP}" \
         && ${lib.getExe jujutsu} git fetch \
         && ${lib.getExe jujutsu} rebase -r "at_operation(@-,trunk()):: ~ ::trunk()" -d "trunk()"  \
-        && ${lib.getExe jujutsu} git push --tracked \
+        && ${lib.getExe jujutsu} git push --tracked --deleted \
         && ${lib.getExe jujutsu} new "trunk()"
     '';
 


### PR DESCRIPTION
With jujutsu 0.28 `jj git push --tracked` no longer includes deleted bookmarks.
