### PR TITLE
Add wrapper to access private repos from nix

### DIFF
--- a/network/openapi/default.nix
+++ b/network/openapi/default.nix
@@ -6,11 +6,7 @@ in
 {
   overlays.openapi = final: prev:
     let
-      extras = {
-        an = {
-          inherit (final) hunspellDicts;
-        };
-      };
+      extras = { };
     in
     lib.foldFor pnames (pname: {
       ${pname} = prev.callPackage

--- a/scripts/nix/default.nix
+++ b/scripts/nix/default.nix
@@ -2,9 +2,10 @@
 
 let
   pnames = [
-    "nix-toplevel"
-    "nix-load-systemd-unit"
     "home-manager-specialisation"
+    "nix-access"
+    "nix-load-systemd-unit"
+    "nix-toplevel"
   ];
 in
 {

--- a/scripts/nix/nix-access.nix
+++ b/scripts/nix/nix-access.nix
@@ -1,0 +1,25 @@
+{ lib
+, gh
+, writers
+}:
+let
+  pname = "nix-access";
+  version = "0.1.0";
+
+  script = writers.writeZshBin "${pname}" ''
+    if [[ -z "''${GITHUB_TOKEN:-}" ]]; then
+      ${lib.getExe gh} auth status || ${lib.getExe gh} auth login
+      typeset GITHUB_TOKEN
+      ${lib.getExe gh} auth token \
+        | read -r GITHUB_TOKEN
+    fi
+
+    NIX_CONFIG="access-tokens = github.com=''${GITHUB_TOKEN?}"
+    export NIX_CONFIG
+
+    "$@"
+  '';
+in
+lib.standalone {
+  inherit version script;
+}


### PR DESCRIPTION
Based on [Use nix flakes with private github deps](https://gist.github.com/arianvp/8f80c23a3410d27746fb97a6563d9677).

This can be used to bootstrap a nix build involving private repos (github only, for now).

```sh
nix run 'github:fore-stun/flakes#nix-access' -- nix build -L
```
