### PR TITLE
Extend wrapper to build toplevel nix system with cli args

### DIFF
--- a/scripts/nix/nix-toplevel.nix
+++ b/scripts/nix/nix-toplevel.nix
@@ -7,6 +7,7 @@ let
 
   script = writers.writeZshBin "${pname}" ''
     zparseopts -D -E -F -- \
+      O=OPT_offline -offline=OPT_offline \
       F:=ARG_flake -flake:=ARG_flake
 
     typeset HOSTNAME="$(hostname -s)"
@@ -20,6 +21,10 @@ let
       --keep-going
       --no-eval-cache
     )
+
+    if (( $#OPT_offline )); then
+      build_args+=(--offline)
+    fi
 
     function nixos() {
       build_args+=(

--- a/scripts/nix/nix-toplevel.nix
+++ b/scripts/nix/nix-toplevel.nix
@@ -9,6 +9,7 @@ let
     zparseopts -D -E -F -- \
       d=OPT_dry_run -dry-run=OPT_dry_run \
       O=OPT_offline -offline=OPT_offline \
+      f+:=ARG_flags -nix-flags+:=ARG_flags \
       F:=ARG_flake -flake:=ARG_flake
 
     typeset HOSTNAME="$(hostname -s)"
@@ -25,6 +26,12 @@ let
 
     if (( $#OPT_offline )); then
       build_args+=(--offline)
+    fi
+
+    if (( $#ARG_flags )); then
+      for _ flag in "''${(@)ARG_flags}"; do
+        build_args+=("''${flag}")
+      done
     fi
 
     function nixos() {

--- a/scripts/nix/nix-toplevel.nix
+++ b/scripts/nix/nix-toplevel.nix
@@ -14,12 +14,15 @@ let
 
     typeset FLAKE="''${ARG_flake[2]:-.}"
 
+    typeset -a build_args=(
+      nix build
+      --print-build-logs
+      --keep-going
+      --no-eval-cache
+    )
+
     function nixos() {
-      local -a build_args=(
-        nix build
-        --print-build-logs
-        --keep-going
-        --no-eval-cache
+      build_args+=(
         "''${FLAKE}#nixosConfigurations.''${(qqq)HOSTNAME}.config.system.build.toplevel"
       )
 
@@ -27,11 +30,7 @@ let
     }
 
     function darwin() {
-      local -a build_args=(
-        nix build
-        --print-build-logs
-        --keep-going
-        --no-eval-cache
+      build_args+=(
         "''${FLAKE}#darwinConfigurations.''${(qqq)HOSTNAME}.system"
       )
 

--- a/scripts/nix/nix-toplevel.nix
+++ b/scripts/nix/nix-toplevel.nix
@@ -7,6 +7,7 @@ let
 
   script = writers.writeZshBin "${pname}" ''
     zparseopts -D -E -F -- \
+      d=OPT_dry_run -dry-run=OPT_dry_run \
       O=OPT_offline -offline=OPT_offline \
       F:=ARG_flake -flake:=ARG_flake
 
@@ -31,6 +32,11 @@ let
         "''${FLAKE}#nixosConfigurations.''${(qqq)HOSTNAME}.config.system.build.toplevel"
       )
 
+      if (( $#OPT_dry_run )); then
+        print -l -- "''${(@)build_args}" >&2
+        return 0
+      fi
+
       systemd-inhibit -- "''${(@)build_args}"
     }
 
@@ -38,6 +44,11 @@ let
       build_args+=(
         "''${FLAKE}#darwinConfigurations.''${(qqq)HOSTNAME}.system"
       )
+
+      if (( $#OPT_dry_run )); then
+        print -l -- "''${(@)build_args}" >&2
+        return 0
+      fi
 
       caffeinate -i -- "''${(@)build_args}"
     }

--- a/scripts/nix/nix-toplevel.nix
+++ b/scripts/nix/nix-toplevel.nix
@@ -9,10 +9,10 @@ let
     zparseopts -D -E -F -- \
       F:=ARG_flake -flake:=ARG_flake
 
-    local HOSTNAME="$(hostname -s)"
-    local PLATFORM="''$([[ "''$(uname)" = "Darwin" ]] && print "darwin" || print "nixos")"
+    typeset HOSTNAME="$(hostname -s)"
+    typeset PLATFORM="''$([[ "''$(uname)" = "Darwin" ]] && print "darwin" || print "nixos")"
 
-    local FLAKE="''${ARG_flake[2]:-.}"
+    typeset FLAKE="''${ARG_flake[2]:-.}"
 
     function nixos() {
       local -a build_args=(

--- a/scripts/nix/nix-toplevel.nix
+++ b/scripts/nix/nix-toplevel.nix
@@ -8,6 +8,7 @@ let
   script = writers.writeZshBin "${pname}" ''
     zparseopts -D -E -F -- \
       d=OPT_dry_run -dry-run=OPT_dry_run \
+      l=OPT_no_link -no-link=OPT_no_link \
       O=OPT_offline -offline=OPT_offline \
       f+:=ARG_flags -nix-flags+:=ARG_flags \
       F:=ARG_flake -flake:=ARG_flake
@@ -26,6 +27,10 @@ let
 
     if (( $#OPT_offline )); then
       build_args+=(--offline)
+    fi
+
+    if (( $#OPT_no_link )); then
+      build_args+=(--no-link --print-out-paths)
     fi
 
     if (( $#ARG_flags )); then


### PR DESCRIPTION
Handles dry-run, not linking output, offline flag and passing arbitrary flags to nix build.
