### PR TITLE
Add script to reorder pdf pages for print

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,7 @@
       ./scripts/jujutsu
       ./scripts/nix
       ./scripts/pandoc
+      ./scripts/pdf
       ./scripts/sync
       ./scripts/system
       ./scripts/text

--- a/scripts/pdf/default.nix
+++ b/scripts/pdf/default.nix
@@ -1,7 +1,9 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ ];
+  pnames = [
+    "pdf-print-reorder"
+  ];
 in
 {
   overlays.pdf = final: prev:

--- a/scripts/pdf/default.nix
+++ b/scripts/pdf/default.nix
@@ -1,0 +1,30 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [ ];
+in
+{
+  overlays.pdf = final: prev:
+    let
+      extras = { };
+    in
+    lib.foldFor pnames (pname: {
+      ${pname} = prev.callPackage (./. + "/${pname}.nix") ({
+        inherit (final) writers;
+        inherit lib;
+      } // extras."${pname}" or { });
+    });
+} //
+lib.foldFor lib.platforms.all (system:
+  {
+    packages.${system} = self.overlays.pdf
+      self.legacyPackages.${system}
+      nixpkgs.legacyPackages.${system};
+  } //
+  lib.foldFor pnames (pname: {
+    apps.${system}.${pname} = {
+      type = "app";
+      program = self.packages.${system}.${pname} + "/bin/${pname}";
+    };
+  })
+)

--- a/scripts/pdf/pdf-print-reorder.nix
+++ b/scripts/pdf/pdf-print-reorder.nix
@@ -1,0 +1,49 @@
+{ lib
+, exiftool
+, qpdf
+, writers
+}:
+let
+  pname = "pdf-print-reorder";
+  version = "0.1.0";
+
+  script = writers.writeZshBin "${pname}" ''
+    pdfPrintReorder() {
+      local INPUT_BASE="''${''${1?Input PDF}:r}"
+
+      local PAGES
+      ${lib.getExe exiftool} -b -PageCount "''${INPUT_BASE}.pdf" | { read -r PAGES || : }
+      if ! (( PAGES )); then
+        print -l -- "Could not ascertain page count" >&2
+        return 3
+      fi
+      print -l -- "Pages: ''${PAGES?}" >&2
+
+      local -a ARGS_qpdf=(
+        "''${INPUT_BASE}.pdf" --pages
+        . 1-z:odd
+      )
+      if (( PAGES % 2 )); then
+        ARGS_qpdf+=(. z-1:even)
+      else
+        ARGS_qpdf+=(. z-1:odd)
+      fi
+      ARGS_qpdf+=(
+        -- "''${INPUT_BASE}_print.pdf"
+      )
+      print -- "''${(@)ARGS_qpdf}" >&2
+
+      read -qs "REPLY?Run qpdf? (y/N)" >&2
+      if [[ "$REPLY" != "y" ]]; then
+        return 2
+      fi
+
+      ${lib.getExe qpdf} "''${(@)ARGS_qpdf}"
+    }
+
+    pdfPrintReorder "$@"
+  '';
+in
+lib.standalone {
+  inherit version script;
+}


### PR DESCRIPTION
All the odd pages first, then all the evens, in reverse order. Works with HP lasertjet manual duplex.
