### PR TITLE
Display bookmarks in jj evolog-check

### DIFF
--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -104,6 +104,7 @@ let
         , self.change_id().short()
         , self.commit_id().short()
         , if(self.conflict(), "conflict", "")
+        , self.bookmarks().join("\t")
         ) ++ "\n"
       JJT
 


### PR DESCRIPTION
It's useful to see the bookmarks on the previous commits.
