### PR TITLE
Remove superfluous sqlite percentile extension

### DIFF
--- a/databases/sqlite/plugins.nix
+++ b/databases/sqlite/plugins.nix
@@ -182,7 +182,6 @@ bundled [
   "fuzzer"
   "ieee754"
   "nextchar"
-  "percentile"
   "prefixes"
   "rot13"
   "series"


### PR DESCRIPTION
As of 3.51 it's built-in and (in nixpkgs) enabled.
