### PR TITLE
Extend simple-markdown with --tac/-T option

### DIFF
--- a/scripts/pandoc/simple-markdown.nix
+++ b/scripts/pandoc/simple-markdown.nix
@@ -138,6 +138,7 @@ let
         -grid-tables=opt_grid_tables G=opt_grid_tables \
         -reference-links=opt_reference_links R=opt_reference_links \
         -no-split=opt_no_split S=opt_no_split \
+        -tac=opt_tac T=opt_tac \
         -markdown=opt_markdown m=opt_markdown
 
       local FROM="$( (( #opt_markdown )) && echo "markdown" || echo "html" )"
@@ -150,6 +151,10 @@ let
         --data-dir=${initLua}
         --wrap=none --lua-filter=${strip}
       )
+
+      if (( #opt_tac )); then
+        PANDOC_ARGS+=(--lua-filter=${lib.getExe tac})
+      fi
 
       if ! (( #opt_no_split )); then
         PANDOC_ARGS+=(--lua-filter=${lib.getExe split})

--- a/scripts/pandoc/simple-markdown.nix
+++ b/scripts/pandoc/simple-markdown.nix
@@ -116,6 +116,21 @@ let
     }
   '';
 
+  tac = writers.writeLuaBin lua "${pname}-tac-filter.lua"
+    {
+      inherit libraries; doCheck = "lua54+pandoc";
+    } ''
+    function Pandoc(doc)
+      local blocks = doc.blocks
+      local n = #blocks
+      local reversed = {}
+      for i = n, 1, -1 do
+        reversed[#reversed + 1] = blocks[i]
+      end
+      return pandoc.Pandoc(reversed, doc.meta)
+    end
+  '';
+
   script = writers.writeZshBin "${pname}" ''
     convertPandoc() {
       zparseopts -D -E -F -- \
@@ -155,5 +170,5 @@ let
 in
 lib.standalone {
   inherit version script;
-  passthru = { inherit initLua strip split; };
+  passthru = { inherit initLua strip split tac; };
 }

--- a/utils/writers/writeLuaBin.nix
+++ b/utils/writers/writeLuaBin.nix
@@ -8,9 +8,23 @@ let
     stds.luacheckrc = { globals = {
       std = {},
     } }
-    stds.pandoc = { read_globals = {
-      pandoc = { other_fields = true },
-    } }
+    stds.pandoc = {
+      read_globals = {
+        pandoc = { other_fields = true },
+      },
+      globals = {
+        "Pandoc",
+        "Blocks",
+        "Inlines",
+        "Meta",
+        "Block",
+        "Inline",
+        "Header",
+        "Para",
+        "CodeBlock",
+        "BlockQuote",
+      },
+    }
   '';
 
   # Vendored from pkgs/build-support/writers/default.nix


### PR DESCRIPTION
Reverse the order of the top-level blocks.
