### PR TITLE
Fix jj-scripts for remote bookmarks syntax deprecation

### DIFF
--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -28,9 +28,14 @@ let
       fi
 
       ${lib.getExe jujutsu} bookmark list --ignore-working-copy -a \
-        | ${lib.getExe gawk} -v REMOTE="''${REMOTE?}" '$1 ~ ("^[^ ]+@" REMOTE ":$") { $1 = substr($1,0,length($1) - 1); print $1 }' \
-        | ${moreutils}/bin/ifne ${lib.getExe fzf} --reverse --ansi --multi --preview="${lib.getExe jujutsu} log -r ::{} --ignore-working-copy --color=always" \
-        | ${moreutils}/bin/ifne ${findutils}/bin/xargs -I {} ${lib.getExe jujutsu} bookmark track {}
+        | ${lib.getExe gawk} \
+          -v REMOTE="''${REMOTE?}" \
+          -v FS=': ' \
+          '$1 ~ ("^[^ ]+@" REMOTE ":$") { $1 = substr($1,0,length($1) - 1); print $1 }' \
+        | ${moreutils}/bin/ifne ${lib.getExe fzf} --reverse --ansi --multi --delimiter='@' \
+            --preview="${lib.getExe jujutsu} log -r '::{1}@{2}' --ignore-working-copy --color=always" \
+        | ${moreutils}/bin/ifne ${coreutils}/bin/cut -d '@' -f 1 \
+        | ${moreutils}/bin/ifne ${findutils}/bin/xargs ${lib.getExe jujutsu} bookmark track --remote="''${REMOTE?}"
     '';
 
     delete-bookmarks = indent ''

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -6,7 +6,6 @@
 , gh
 , jujutsu
 , moreutils
-, ripgrep
 , writers
 }:
 let

--- a/scripts/jujutsu/jj-scripts.nix
+++ b/scripts/jujutsu/jj-scripts.nix
@@ -181,7 +181,8 @@ let
 
     gh-pr-view = indent ''
       local TIP
-      ${lib.getExe jujutsu} bookmark list -r "heads(::@- & bookmarks())" -T "name" --no-pager \
+      ${lib.getExe jujutsu} bookmark list -r "heads(::@- & bookmarks())" -T "name ++ ':'" --no-pager --ignore-working-copy \
+        | ${moreutils}/bin/ifne ${coreutils}/bin/cut -d ':' -f 1 \
         | { read -r TIP || : }
 
       ${lib.getExe gh} pr view --web "''${TIP}"


### PR DESCRIPTION
```console
Warning: <bookmark>@<remote> syntax is deprecated, use `<bookmark> --remote=<remote>` instead.
```

Also fixes a bug with `gh-pr-view` where the branch isn't pushed (possibly a workaround for an upstream jujutsu bug).
