### PR TITLE
Update caddy to handle new cloudflare token format

### DIFF
--- a/servers/caddy/caddy-extended.nix
+++ b/servers/caddy/caddy-extended.nix
@@ -4,7 +4,7 @@
 caddy.withPlugins {
   plugins = [
     # Caddy dns
-    "github.com/caddy-dns/cloudflare@v0.2.2"
+    "github.com/caddy-dns/cloudflare@v0.2.4"
     "github.com/fore-stun/libdns-route53@v0.0.0-20250526213255-7a723d8255bf"
 
     "github.com/fore-stun/spanx@v0.0.0-20250507102219-58d4b8a0d7f3"
@@ -14,5 +14,5 @@ caddy.withPlugins {
     "github.com/abiosoft/caddy-inspect@v0.0.0-20250214103948-96cdb1dfb122"
     "github.com/ggicci/caddy-jwt@v0.12.0"
   ];
-  hash = "sha256-5atshd1aaTT7KovZLJa+qaDsP/GJFB3GiRNVPh2tVE8=";
+  hash = "sha256-5Og2rKcwpTIKgqOQPDrm0adpWKbQQIkdvI9HNfZ7ryA=";
 }


### PR DESCRIPTION
The caddy plugin was too strict in its parser, and this was fixed in caddy-dns/cloudflare#123
