### PR TITLE
Add (filesystem) cache plugins to caddy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
       ./utils/wayland
 
       ./scripts/darwin
+      ./scripts/go
       ./scripts/jujutsu
       ./scripts/nix
       ./scripts/pandoc

--- a/scripts/go/default.nix
+++ b/scripts/go/default.nix
@@ -1,7 +1,9 @@
 { self, lib, nixpkgs, ... }:
 
 let
-  pnames = [ ];
+  pnames = [
+    "go-resolve-module"
+  ];
 
 in
 {

--- a/scripts/go/default.nix
+++ b/scripts/go/default.nix
@@ -1,0 +1,32 @@
+{ self, lib, nixpkgs, ... }:
+
+let
+  pnames = [ ];
+
+in
+{
+  overlays.go-script = final: prev:
+    let
+      extras = { };
+    in
+    lib.foldFor pnames (pname: {
+      ${pname} =
+        lib.callPackageWith prev (./. + "/${pname}.nix") (
+          extras.${pname} or {
+            inherit (final) writers;
+            inherit lib;
+          }
+        );
+    });
+} //
+lib.foldFor lib.platforms.all (system:
+  let
+    pkgs = nixpkgs.legacyPackages.${system};
+  in
+  {
+    packages.${system} =
+      lib.filterAttrs (_: lib.isDerivation) self.legacyPackages.${system} // { };
+    legacyPackages.${system} = self.overlays.go-script
+      self.legacyPackages.${system}
+      pkgs;
+  })

--- a/scripts/go/go-resolve-module.nix
+++ b/scripts/go/go-resolve-module.nix
@@ -1,4 +1,7 @@
 { lib
+, gh
+, gnused
+, jq
 , writers
 }:
 let
@@ -6,6 +9,70 @@ let
   version = "0.1.0";
 
   script = writers.writeZshBin "${pname}" ''
+    resolvePlugin() {
+      zparseopts -D -E -F -- \
+        n=OPT_dry_run -dry-run=OPT_dry_run
+
+      local INPUT="''${1?Input URL}"
+      local REPO
+      local TAG
+      ${lib.getExe gnused} -r \
+          -e 's#@#/#g' \
+          -e 's#^(https://)?github.com/([^/]+/[^/]+)[/](.+)#\2 \3#' \
+          <<< "$INPUT" \
+        | read -r REPO TAG
+      local MODULE="''${(L)INPUT%@*}"
+      print -l -- "Input:" "  MODULE: ''${MODULE}" "  REPO: ''${REPO}" "  TAG: ''${TAG}" >&2
+
+      if (( $#OPT_dry_run )); then
+        return 0
+      fi
+
+      print -l -- "Resolving version with github API" >&2
+
+      local GO_VERSION
+      ${lib.getExe gh} api "repos/''${REPO?}/commits/''${TAG?}" \
+        | ${lib.getExe jq} -r '"v0.0.0-" + (.commit.committer.date | gsub("[-T:Z]"; "")) + "-" + .sha[0:12]' \
+        | { read -r -d "" GO_VERSION || : }
+
+      local PLUGIN_URL="''${MODULE?}@''${GO_VERSION?}"
+      print -- "''${(qqq)PLUGIN_URL}"
+    }
+
+    resolvePlugins() {
+      zparseopts -D -E -F -- \
+        v=OPT_verbose -verbose=OPT_verbose \
+        n=OPT_dry_run -dry-run=OPT_dry_run
+
+      local -a inargs=("''${(@)@}")
+      if ! (( $#@ )); then
+        if [[ -t 0 ]]; then
+          print -- "No arguments supplied" >&2
+          return 3
+        fi
+        local INARGS
+        read -r -d "" INARGS || :
+        inargs=("''${(f)INARGS}")
+        unset INARGS
+      fi
+
+      if (( $#inargs )); then
+        for arg in "''${(@)inargs}"; do
+          local -a args=()
+          if (( $#OPT_dry_run )); then
+            args+=("-n")
+          fi
+          args+=("$arg")
+          if (( $#OPT_verbose )); then
+            resolvePlugin "''${(@)args}" || :
+          else
+            resolvePlugin "''${(@)args}" 2>/dev/null || :
+          fi
+        done
+      fi
+    }
+
+    resolvePlugins "$@"
   '';
 
 in

--- a/scripts/go/go-resolve-module.nix
+++ b/scripts/go/go-resolve-module.nix
@@ -1,0 +1,14 @@
+{ lib
+, writers
+}:
+let
+  pname = "go-resolve-module";
+  version = "0.1.0";
+
+  script = writers.writeZshBin "${pname}" ''
+  '';
+
+in
+lib.standalone {
+  inherit version script;
+}

--- a/servers/caddy/caddy-extended.nix
+++ b/servers/caddy/caddy-extended.nix
@@ -11,6 +11,8 @@ let
       "github.com/caddy-dns/cloudflare@v0.2.4"
       "github.com/fore-stun/libdns-route53@v0.0.0-20250526213255-7a723d8255bf"
 
+      "github.com/darkweak/souin/plugins/caddy@v0.0.0-20250918155659-fd6fa5346ff7"
+      "github.com/darkweak/storages/simplefs/caddy@v0.0.0-20260314111132-4696add7353c"
       "github.com/quix-labs/caddy-image-processor@v0.0.0-20241215121258-b4aa0b5bac30"
       "github.com/fore-stun/spanx@v0.0.0-20250507102219-58d4b8a0d7f3"
       "github.com/fore-stun/caddy-s3-proxy@v0.5.7-0.20250526214057-c90e95199238"
@@ -19,7 +21,7 @@ let
       "github.com/abiosoft/caddy-inspect@v0.0.0-20250214103948-96cdb1dfb122"
       "github.com/ggicci/caddy-jwt@v0.12.0"
     ];
-    hash = "sha256-HJOljfduiwxjJQ+fRo8tKZkXNDVjQena36QLxV1yfHU=";
+    hash = "sha256-3yB9p2j7rw7aUWjh5rgMyVXrclwXFqPbs5HmQOPAhDU=";
   };
 
   withDeps = drv: drv.overrideAttrs (old: {


### PR DESCRIPTION
Also I added the `go-resolve-module` script to use the github cli to extract the go versions from github versions.

Caching uses [darkweak/souin: An HTTP cache system, RFC compliant, compatible with @tyktechnologies, @traefik, @caddyserver, @go-chi, @bnkamalesh, @beego, @devfeel, @labstack, @gofiber, @go-goyave, @go-kratos, @gin-gonic, @roadrunner-server, @zalando, @zeromicro, @nginx and @apache](https://github.com/darkweak/souin).
Storage uses [Simplefs | Souin's documentation](https://docs.souin.io/docs/storages/simplefs/).
